### PR TITLE
Added a mechanism to fetch details about jahia version and installed modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ Using Mocha JSON or JEST/JUNIT XML as input, jahia-reporter is a CLI tool built 
 
 ## Available Commands
 
-| Command   | Description                                                                                                                                                   |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| testrail  | Sends content of the report to a given testrail project (by name, project must be created in advance). Automatically creates milestones, runs and test cases. |
-| slack     | Sends slack notification based on the content of a report                                                                                                     |
-| zencrepes | Sends testing status to ZenCrepes with the objective of building a testing matrix for dependencies                                                            |
+| Command       | Description                                                                                                                                                   |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| testrail      | Sends content of the report to a given testrail project (by name, project must be created in advance). Automatically creates milestones, runs and test cases. |
+| slack         | Sends slack notification based on the content of a report                                                                                                     |
+| zencrepes     | Sends testing status to ZenCrepes with the objective of building a testing matrix for dependencies                                                            |
+| utils:modules | Returns details about current Jahia version and installed modules                                                                                             |
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/uuid": "^8.3.0",
     "date-fns-timezone": "^0.1.4",
     "glob": "^7.1.6",
+    "js-base64": "^3.6.0",
     "ts-node": "^8",
     "ts-sync-request": "^1.4.1",
     "tslib": "^1",
@@ -49,7 +50,12 @@
   "main": "lib/index.js",
   "oclif": {
     "commands": "./lib/commands",
-    "bin": "jahia-reporter"
+    "bin": "jahia-reporter",
+    "topics": {
+      "utils": {
+        "description": "Set of small utility funtions"
+      }
+    }
   },
   "repository": "VladRadan/jahia-reporter",
   "scripts": {

--- a/src/commands/utils/modules.ts
+++ b/src/commands/utils/modules.ts
@@ -1,0 +1,53 @@
+import {Command, flags} from '@oclif/command'
+import * as fs from 'fs'
+import * as path from 'path'
+
+import {UtilsVersions} from '../../global.type'
+
+import {getModules} from '../../utils/modules'
+
+class JahiaUtilsModule extends Command {
+  static description = 'For a provided module, returns the module version, Jahia version and list of installed modules'
+
+  static args = [
+    {name: 'jahiaUrl',
+      required: true,
+      description: 'Jahia GraphQL endpoint (i.e. http://localhost:8080/modules/graphql)',
+      default: 'http://localhost:8080/modules/graphql'},
+    {name: 'jahiaUsername',
+      required: true,
+      description: 'Jahia username'},
+    {name: 'jahiaPassword',
+      required: true,
+      description: 'Jahia password'},
+  ]
+
+  static flags = {
+    // add --version flag to show CLI version
+    version: flags.version({char: 'v'}),
+    help: flags.help({char: 'h'}),
+    module: flags.string({
+      char: 'm',
+      description: 'Module ID',
+      required: true,
+    }),
+    filepath: flags.string({
+      char: 'f',
+      description: 'Filepath to store the resulting JSON to',
+      required: true,
+    }),
+  }
+
+  async run() {
+    const {args, flags} = this.parse(JahiaUtilsModule)
+
+    const version: UtilsVersions = getModules(flags.module, args.jahiaUrl, args.jahiaUsername, args.jahiaPassword)
+
+    fs.writeFileSync(
+      path.join(flags.filepath),
+      JSON.stringify(version)
+    )
+  }
+}
+
+export = JahiaUtilsModule

--- a/src/global.type.ts
+++ b/src/global.type.ts
@@ -58,3 +58,19 @@ export interface ZenCrepesStateNode {
   runFailure: number;
   runDuration: number;
 }
+
+export interface JahiaModule {
+    id: string;
+    name: string;
+    version: string;
+}
+
+export interface UtilsVersions {
+  jahia: {
+    version: string;
+    build: string;
+    fullVersion: string;
+  };
+  module: JahiaModule;
+  allModules: JahiaModule[];
+}

--- a/src/utils/modules.ts
+++ b/src/utils/modules.ts
@@ -1,0 +1,67 @@
+import {SyncRequestClient} from 'ts-sync-request/dist'
+import {Base64} from 'js-base64'
+
+import {UtilsVersions, JahiaModule} from '../global.type'
+
+export const getJahiaVersion = (version: string) => {
+  if (version === 'UNKOWN') {
+    return {
+      fullVersion: 'UNKOWN',
+      version: 'UNKOWN',
+      build: 'UNKOWN',
+    }
+  }
+
+  let jahiaBuild = 'UNKNOWN'
+  const findBuild = version.match(/Build (.*)/)
+  if (findBuild !== null) {
+    jahiaBuild = findBuild[1]
+  }
+
+  let jahiaVersion = 'UNKNOWN'
+  const findVersion = version.match(/Jahia (.*) \[/)
+  if (findVersion !== null) {
+    jahiaVersion = findVersion[1]
+  }
+
+  return {
+    fullVersion: version,
+    version: jahiaVersion,
+    build: jahiaBuild,
+  }
+}
+
+export const getModules = (moduleId: string, jahiaUrl: string, jahiaUsername: string, jahiaPassword: string) => {
+  const authHeader = `Basic ${Base64.btoa(jahiaUsername + ':' + jahiaPassword)}`
+
+  // Simple graphql call to fetch the query
+  let response: any = new SyncRequestClient()
+  .addHeader('Content-Type', 'application/json')
+  .addHeader('authorization', authHeader)
+  .post(jahiaUrl, {query: 'query { admin { version } dashboard { modules { id name version } } }'})
+
+  if (response.errors !== undefined) {
+    // There might be cases in which the admin node is not installed (older version of graphql-dxm-provider)
+    // In that case, we re-run the query without the admin node
+    response = new SyncRequestClient()
+    .addHeader('Content-Type', 'application/json')
+    .addHeader('authorization', authHeader)
+
+    .post(jahiaUrl, {query: 'query { dashboard { modules { id name version } } }'})
+  }
+
+  // console.log(response.data);
+  // console.log(response.data.dashboard.modules)
+  const module = response.data.dashboard.modules.find((m: JahiaModule) => m.id === moduleId)
+
+  const version: UtilsVersions = {
+    jahia: response.data.admin === undefined ? getJahiaVersion('UNKNOWN') : getJahiaVersion(response.data.admin.version),
+    module: module === undefined ? {
+      id: moduleId,
+      name: 'UNKNOWN',
+      version: 'UNKOWN',
+    } : module,
+    allModules: response.data.dashboard.modules,
+  }
+  return version
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,6 +1709,11 @@ istanbul-reports@^2.2.4:
   dependencies:
     html-escaper "^2.0.0"
 
+js-base64@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.6.0.tgz#773e1de628f4f298d65a7e9842c50244751f5756"
+  integrity sha512-wVdUBYQeY2gY73RIlPrysvpYx+2vheGo8Y1SNQv/BzHToWpAZzJU7Z6uheKMAe+GLSBig5/Ps2nxg/8tRB73xg==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
Fetch from Jahia GraphQL API, the installed modules and jahia version, and stores the details in a file.

This file can then be used for sending slack messages.

Using a file to avoid having to call the API many times, the file can be stored alongside the workspace and used in other jobs.
