### PR TITLE
Updated slack message in the event environment was not setup properly

### DIFF
--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -79,7 +79,7 @@ class JahiaSlackReporter extends Command {
       } else {
         module = `${version.module.name} v${version.module.version} (Jahia: ${version.jahia.version}-${version.jahia.build})`
       }
-      if (version.module.name === 'UNKNOWN' && version.jahia.version === 'UNKNOWN') {
+      if (version.module.name === 'UNKNOWN') {
         msg = `Error setting up executing tests in run: ${flags.runUrl}`
       }
     }


### PR DESCRIPTION
The objective here is not to send a lengthy message with tons of test errors if it was actually the environment that wasn't setup properly in the first place (i.e. for example when we have nexus unavailable).