### PR TITLE
added API limit catch that waits 90 seconds before retrying

### DIFF
--- a/src/utils/testrail.ts
+++ b/src/utils/testrail.ts
@@ -126,7 +126,7 @@ export class TestRailClient {
             .post(url, data)
           }
         } catch (error) {
-          if (error.statusCodes === 429) {
+          if (error.statusCode === 429) {
             // eslint-disable-next-line no-console
             console.log(`Failed to send ${method} request to ${uri}. Maximum number of allowed API calls per minute reached. Waiting 90 seconds...`)
             Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 90000)

--- a/src/utils/testrail.ts
+++ b/src/utils/testrail.ts
@@ -126,10 +126,16 @@ export class TestRailClient {
             .post(url, data)
           }
         } catch (error) {
-          // eslint-disable-next-line no-console
-          console.log(`Failed to send ${method} request to ${uri} with data ${JSON.stringify(data, null, 4)}:\n${(error as Error).message}`)
-          const randomWait: number = Math.floor(Math.random() * 200)
-          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, randomWait)
+          if (error.statusCodes === 429) {
+            // eslint-disable-next-line no-console
+            console.log(`Failed to send ${method} request to ${uri}. Maximum number of allowed API calls per minute reached. Waiting 90 seconds...`)
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 90000)
+          } else {
+            // eslint-disable-next-line no-console
+            console.log(`Failed to send ${method} request to ${uri} with data ${JSON.stringify(data, null, 4)}:\n${(error as Error).message}`)
+            const randomWait: number = Math.floor(Math.random() * 200)
+            Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, randomWait)
+          }
         }
       }
     }


### PR DESCRIPTION
The call fails when more than 180 API calls have been made in a minute. 
Their own response suggests waiting 5 second before retrying, added a 90 seconds wait because the likeliest scenario is that we just made those 180 calls in the last 2 seconds. 90 seconds should put us in the clear (and avoid conflict with another potential run).
Open to suggestions though