### PR TITLE
Added a fallback to get the list of modules from module-manager REST API

### DIFF
--- a/src/commands/utils/modules.ts
+++ b/src/commands/utils/modules.ts
@@ -13,8 +13,8 @@ class JahiaUtilsModule extends Command {
     version: flags.version({char: 'v'}),
     help: flags.help({char: 'h'}),
     jahiaUrl: flags.string({
-      description: 'Jahia GraphQL endpoint (i.e. http://localhost:8080/modules/graphql)',
-      default: 'http://localhost:8080/modules/graphql',
+      description: 'Jahia GraphQL endpoint (i.e. http://localhost:8080/)',
+      default: 'http://localhost:8080/',
     }),
     jahiaUsername: flags.string({
       description: 'Jahia username used to authenticated with the remote endpoint)',

--- a/src/utils/modules.ts
+++ b/src/utils/modules.ts
@@ -1,7 +1,7 @@
 import {SyncRequestClient} from 'ts-sync-request/dist'
 import {Base64} from 'js-base64'
 
-import {UtilsVersions, JahiaModule} from '../global.type'
+import {JahiaModule} from '../global.type'
 
 export const getJahiaVersion = (version: string) => {
   if (version === 'UNKOWN') {
@@ -37,6 +37,21 @@ export const getJahiaVersion = (version: string) => {
   }
 }
 
+const parseModuleManagerData = (response: any) => {
+  const instanceModules: any = Object.values(response)[0]
+  const modules = []
+  const regExp = new RegExp(/org\.jahia\.modules\/(.*)\/(.*)/)
+
+  const instanceModulesArr: Array<any> = Object.entries(instanceModules)
+  for (const [key, value] of instanceModulesArr) {
+    const ex = regExp.exec(key)
+    if (ex !== null) {
+      modules.push({...value, id: ex[1], version: ex[2], name: ex[1]})
+    }
+  }
+  return modules
+}
+
 // eslint-disable-next-line max-params
 export const getModules = (moduleId: string, dependencies: string[], jahiaUrl: string, jahiaUsername: string, jahiaPassword: string) => {
   const authHeader = `Basic ${Base64.btoa(jahiaUsername + ':' + jahiaPassword)}`
@@ -45,7 +60,7 @@ export const getModules = (moduleId: string, dependencies: string[], jahiaUrl: s
   let response: any = new SyncRequestClient()
   .addHeader('Content-Type', 'application/json')
   .addHeader('authorization', authHeader)
-  .post(jahiaUrl, {query: 'query { admin { version } dashboard { modules { id name version } } }'})
+  .post(jahiaUrl + 'modules/graphql', {query: 'query { admin { version } dashboard { modules { id name version } } }'})
 
   if (response.errors !== undefined) {
     // There might be cases in which the admin node is not installed (older version of graphql-dxm-provider)
@@ -53,25 +68,59 @@ export const getModules = (moduleId: string, dependencies: string[], jahiaUrl: s
     response = new SyncRequestClient()
     .addHeader('Content-Type', 'application/json')
     .addHeader('authorization', authHeader)
-
-    .post(jahiaUrl, {query: 'query { dashboard { modules { id name version } } }'})
+    .post(jahiaUrl + 'modules/graphql', {query: 'query { dashboard { modules { id name version } } }'})
   }
 
-  // console.log(response.data);
-  // console.log(response.data.dashboard.modules)
-  const module = response.data.dashboard.modules.find((m: JahiaModule) => m.id === moduleId)
+  // Jahia 8 with the GraphQL dashboard node available
+  if (response.data !== null) {
+    const module = response.data.dashboard.modules.find((m: JahiaModule) => m.id === moduleId)
 
-  const version: UtilsVersions = {
-    jahia: response.data.admin === undefined ? getJahiaVersion('UNKNOWN') : getJahiaVersion(response.data.admin.version),
-    module: module === undefined ? {
+    return {
+      jahia: response.data.admin === undefined ? getJahiaVersion('UNKNOWN') : getJahiaVersion(response.data.admin.version),
+      module: module === undefined ? {
+        id: moduleId,
+        name: 'UNKNOWN',
+        version: 'UNKOWN',
+      } : module,
+      dependencies: dependencies
+      .map((d: string) => response.data.dashboard.modules.find((m: {id: string}) => m.id === d))
+      .filter((d: {id: string} | undefined) => d !== undefined),
+      allModules: response.data.dashboard.modules,
+    }
+  }
+
+  // If GraphQL Dashboard node is not available, falling back to the module manager REST API
+  response = new SyncRequestClient()
+  .addHeader('Content-Type', 'application/json')
+  .addHeader('authorization', authHeader)
+  .get(jahiaUrl + 'modules/api/bundles/org.jahia.modules/*/*/_info')
+
+  if (Object.values(response).length > 0) {
+    const modules: any = parseModuleManagerData(response)
+    const module = modules.find((m: JahiaModule) => m.id === moduleId)
+    return {
+      jahia: getJahiaVersion('UNKNOWN'),
+      module: module === undefined ? {
+        id: moduleId,
+        name: 'UNKNOWN',
+        version: 'UNKOWN',
+      } : module,
+      dependencies: dependencies
+      .map((d: string) => modules.find((m: {id: string}) => m.id === d))
+      .filter((d: {id: string} | undefined) => d !== undefined),
+      allModules: modules,
+    }
+  }
+
+  // Othwerise return empty data
+  return {
+    jahia: getJahiaVersion('UNKNOWN'),
+    module: {
       id: moduleId,
       name: 'UNKNOWN',
       version: 'UNKOWN',
-    } : module,
-    dependencies: dependencies
-    .map((d: string) => response.data.dashboard.modules.find((m: {id: string}) => m.id === d))
-    .filter((d: {id: string} | undefined) => d !== undefined),
-    allModules: response.data.dashboard.modules,
+    },
+    dependencies: [],
+    allModules: [],
   }
-  return version
 }

--- a/src/utils/modules.ts
+++ b/src/utils/modules.ts
@@ -4,11 +4,11 @@ import {Base64} from 'js-base64'
 import {JahiaModule} from '../global.type'
 
 export const getJahiaVersion = (version: string) => {
-  if (version === 'UNKOWN') {
+  if (version === 'UNKNOWN') {
     return {
-      fullVersion: 'UNKOWN',
-      version: 'UNKOWN',
-      build: 'UNKOWN',
+      fullVersion: 'UNKNOWN',
+      version: 'UNKNOWN',
+      build: 'UNKNOWN',
     }
   }
 
@@ -80,7 +80,7 @@ export const getModules = (moduleId: string, dependencies: string[], jahiaUrl: s
       module: module === undefined ? {
         id: moduleId,
         name: 'UNKNOWN',
-        version: 'UNKOWN',
+        version: 'UNKNOWN',
       } : module,
       dependencies: dependencies
       .map((d: string) => response.data.dashboard.modules.find((m: {id: string}) => m.id === d))
@@ -103,7 +103,7 @@ export const getModules = (moduleId: string, dependencies: string[], jahiaUrl: s
       module: module === undefined ? {
         id: moduleId,
         name: 'UNKNOWN',
-        version: 'UNKOWN',
+        version: 'UNKNOWN',
       } : module,
       dependencies: dependencies
       .map((d: string) => modules.find((m: {id: string}) => m.id === d))
@@ -118,7 +118,7 @@ export const getModules = (moduleId: string, dependencies: string[], jahiaUrl: s
     module: {
       id: moduleId,
       name: 'UNKNOWN',
-      version: 'UNKOWN',
+      version: 'UNKNOWN',
     },
     dependencies: [],
     allModules: [],


### PR DESCRIPTION
The previous version of jahia-reporter was failing if the dashboard Graphql node was not available.

Since it is not available for Jahia 7, added a fallback call to the module API to get the list of installed modules.