### PR TITLE
Added command to install a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/node": "^10",
     "@types/node-fetch": "^2.5.7",
     "@types/uuid": "^8.3.0",
+    "axios": "^0.21.1",
     "date-fns-timezone": "^0.1.4",
     "glob": "^7.1.6",
     "js-base64": "^3.6.0",

--- a/src/commands/utils/module.ts
+++ b/src/commands/utils/module.ts
@@ -1,0 +1,89 @@
+import {Command, flags} from '@oclif/command'
+import {performance} from 'perf_hooks'
+import * as fs from 'fs'
+
+import installModule from '../../utils/install-module'
+import uninstallModule from '../../utils/uninstall-module'
+import {getModules} from '../../utils/modules'
+
+class JahiaUtilsModule extends Command {
+  static description = 'Install a module and remove any previous installed version of that module'
+
+  static flags = {
+    version: flags.version({char: 'v'}),
+    help: flags.help({char: 'h'}),
+    jahiaUrl: flags.string({
+      description: 'Jahia GraphQL endpoint (i.e. http://localhost:8080/)',
+      default: 'http://localhost:8080/',
+    }),
+    jahiaUsername: flags.string({
+      description: 'Jahia username used to authenticated with the remote endpoint',
+      default: 'root',
+    }),
+    jahiaPassword: flags.string({
+      description: 'Jahia password used to authenticated with the remote endpoint',
+      default: 'root',
+    }),
+    moduleId: flags.string({
+      description: 'Module ID of the module currently being tested',
+      required: true,
+    }),
+    moduleFile: flags.string({
+      description: 'Specify the filepath to the module to be installed (jar on filesystem)',
+      required: true,
+    }),
+  }
+
+  async run() {
+    const {flags} = this.parse(JahiaUtilsModule)
+    const t0 = performance.now()
+
+    if (!fs.existsSync(flags.moduleFile)) {
+      this.log('ERROR: Unable to access file: ' + flags.moduleFile)
+      this.exit(1)
+    }
+
+    const jahiaFullUrl = flags.jahiaUrl.slice(-1) === '/' ? flags.jahiaUrl : flags.jahiaUrl + '/'
+
+    this.log('Get list of installed modules')
+    let installedModules = await getModules(flags.moduleId, [], jahiaFullUrl, flags.jahiaUsername, flags.jahiaPassword)
+    let installMod: Array<{id: string}> = installedModules.allModules.filter((m: { id: string}) => m.id === flags.moduleId)
+    if (installMod.length > 0) {
+      this.log(`A version of this module is already installed: ${JSON.stringify(installMod)}`)
+    } else {
+      this.log(`No previous versions of module ${flags.moduleId} detected on the system`)
+    }
+
+    const install: any = await installModule(jahiaFullUrl, flags.jahiaUsername, flags.jahiaPassword, flags.moduleFile)
+    if (install.length > 0) {
+      this.log(`Module succesfully submitted for installation, response: ${JSON.stringify(install[0])}`)
+      installedModules = await getModules(flags.moduleId, [], jahiaFullUrl, flags.jahiaUsername, flags.jahiaPassword)
+
+      // There might be occurences during which the installation of a newer version of a module doesn't uninstall a previous version and this might cause some issues (i.e. with graphql-dxm-provider)
+      // So we first inatll the module, then look for any previously version that might still be present, then uninstall these previous version.
+      // For some obscure reasons, the version returned by module manager is different from the version returned by the install payload (. instead of -)
+      // Stripping all non-alphanumerical characters for the comparison
+      const otherVersionsSameModule = installedModules.allModules.filter((m: { id: string; version: string }) => m.id === flags.moduleId && m.version.replace(/[^0-9a-z]/gi, '') !== install[0].version.replace(/[^0-9a-z]/gi, ''))
+      if (otherVersionsSameModule.length > 0) {
+        this.log('A previous version of this module is on the system, it will be removed')
+        this.log(JSON.stringify(otherVersionsSameModule))
+        for (const otherMod of otherVersionsSameModule) {
+          this.log(`Removal of module: ${JSON.stringify(otherMod)}`)
+          // eslint-disable-next-line no-await-in-loop
+          const uninstall: any = await uninstallModule(jahiaFullUrl, flags.jahiaUsername, flags.jahiaPassword, otherMod.id, otherMod.version)
+          this.log('The following module was uninstalled: ')
+          this.log(JSON.stringify(uninstall))
+        }
+      }
+    }
+
+    installedModules = await getModules(flags.moduleId, [], jahiaFullUrl, flags.jahiaUsername, flags.jahiaPassword)
+    installMod = installedModules.allModules.filter((m: { id: string}) => m.id === flags.moduleId)
+    this.log(`The following versions of the module are installed: ${JSON.stringify(installMod)}`)
+
+    const t1 = performance.now()
+    this.log('Total Execution time: ' + Math.round(t1 - t0) + ' milliseconds.')
+  }
+}
+
+export = JahiaUtilsModule

--- a/src/utils/install-module.ts
+++ b/src/utils/install-module.ts
@@ -1,0 +1,47 @@
+import axios from 'axios'
+import * as FormData from 'form-data'
+import * as fs from 'fs'
+
+import {exit} from '@oclif/errors'
+
+const installModule = async (
+  jahiaUrl: string,
+  jahiaUsername: string,
+  jahiaPassword: string,
+  moduleFile: string,
+) => {
+  const form = new FormData()
+  const stream = fs.createReadStream(moduleFile)
+  form.append('bundle', stream)
+  form.append('start', 'true')
+
+  // In Node.js environment you need to set boundary in the header field 'Content-Type' by calling method `getHeaders`
+  const formHeaders = form.getHeaders()
+
+  let installResponse: any = {}
+  try {
+    installResponse = await axios.post(jahiaUrl + 'modules/api/bundles', form, {
+      headers: {
+        ...formHeaders,
+      },
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
+      auth: {
+        username: jahiaUsername,
+        password: jahiaPassword,
+      },
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error)
+    exit(1)
+  }
+  if (installResponse.data !== undefined) {
+    return installResponse.data.bundleInfos
+  }
+  // eslint-disable-next-line no-console
+  console.log(`Unable to install module: ${JSON.stringify(installResponse)}`)
+  exit(1)
+}
+
+export default installModule

--- a/src/utils/uninstall-module.ts
+++ b/src/utils/uninstall-module.ts
@@ -1,0 +1,40 @@
+import axios from 'axios'
+import {exit} from '@oclif/errors'
+
+const uninstallModule = async (
+  jahiaUrl: string,
+  jahiaUsername: string,
+  jahiaPassword: string,
+  moduleId: string,
+  moduleVersion: string,
+// eslint-disable-next-line max-params
+) => {
+  // If module is a snaphsot, the key is different than the version, with a . instead of a -
+  let moduleKey: string = moduleId + '/' + moduleVersion
+  if (moduleKey.includes('SNAPSHOT')) {
+    moduleKey = moduleKey.replace('-SNAPSHOT', '.SNAPSHOT')
+  }
+  let installResponse: any = {}
+  try {
+    installResponse = await axios.post(jahiaUrl + 'modules/api/bundles/org.jahia.modules/' + moduleKey + '/_uninstall', null, {
+      maxContentLength: Infinity,
+      maxBodyLength: Infinity,
+      auth: {
+        username: jahiaUsername,
+        password: jahiaPassword,
+      },
+    })
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(error)
+    exit(1)
+  }
+  if (installResponse.data !== undefined) {
+    return installResponse.data.bundleInfos
+  }
+  // eslint-disable-next-line no-console
+  console.log(`Unable to uninstall module: ${JSON.stringify(installResponse)}`)
+  exit(1)
+}
+
+export default uninstallModule

--- a/yarn.lock
+++ b/yarn.lock
@@ -489,6 +489,13 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -1271,6 +1278,11 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+follow-redirects@^1.10.0:
+  version "1.13.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.2.tgz#dd73c8effc12728ba5cf4259d760ea5fb83e3147"
+  integrity sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
 
 foreground-child@^1.5.6:
   version "1.5.6"


### PR DESCRIPTION
If we want to install a module that was just built (but not in nexus yet), we need to be able to submit it to Jahia. 

This would not be supported by the provisioning API since jahia wouldn't have a way to get that artifact.