### PR TITLE
Updated to get all installed modules, not just the ones under org.jahia.modules

### DIFF
--- a/src/utils/modules.ts
+++ b/src/utils/modules.ts
@@ -40,7 +40,7 @@ export const getJahiaVersion = (version: string) => {
 const parseModuleManagerData = (response: any) => {
   const instanceModules: any = Object.values(response)[0]
   const modules = []
-  const regExp = new RegExp(/org\.jahia\.modules\/(.*)\/(.*)/)
+  const regExp = new RegExp(/.*\/(.*)\/(.*)/)
 
   const instanceModulesArr: Array<any> = Object.entries(instanceModules)
   for (const [key, value] of instanceModulesArr) {


### PR DESCRIPTION
Description in the title, this was causing an issue with copy-to-other-languages which is published under `org.jahia.se.modules`