### PR TITLE
Rolled back to browser-or-node 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "nyc": "^14",
     "ts-jest": "^27.0.7"
   },
+  "resolutions": {
+    "browser-or-node": "1.3.0"
+  },  
   "engines": {
     "node": ">=8.10.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1366,7 +1366,7 @@ braces@^3.0.1:
   dependencies:
     fill-range "^7.0.1"
 
-browser-or-node@^1.3.0:
+browser-or-node@1.3.0, browser-or-node@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-or-node/-/browser-or-node-1.3.0.tgz#f2a4e8568f60263050a6714b2cc236bb976647a7"
   integrity sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==


### PR DESCRIPTION
Following an issue with v2.1.0

https://github.com/flexdinesh/browser-or-node/issues/22