### PR TITLE
QABACKLOG-1363: Adding support for testrail custom fields

### DIFF
--- a/src/commands/testrail.ts
+++ b/src/commands/testrail.ts
@@ -17,7 +17,7 @@ import {
 import {formatToTimeZone} from 'date-fns-timezone'
 import {JRRun, JRTestfailure} from '../global.type'
 import ingestReport from '../utils/ingest'
-import { cli } from 'cli-ux'
+import {cli} from 'cli-ux'
 import {lstatSync, readFileSync} from 'fs'
 
 interface TestWithStatus extends Test {
@@ -49,7 +49,7 @@ class JahiaTestrailReporter extends Command {
     testrailApiKey: flags.string({
       description: 'TestRail to be used as an alternative to username/password',
       required: false,
-    }),    
+    }),
     testrailUsername: flags.string({
       description: 'TestRail username',
       required: true,
@@ -61,7 +61,7 @@ class JahiaTestrailReporter extends Command {
     testrailCustomResultFields: flags.string({
       description: 'Path to a file containing values (in a key:value JSON object) to be added to the result fields',
       default: '',
-    }),    
+    }),
     projectName: flags.string({
       char: 'n',
       description: 'TestRail Project name',
@@ -232,7 +232,7 @@ class JahiaTestrailReporter extends Command {
     if (flags.testrailCustomResultFields !== undefined) {
       // Parse the provided json file
       if (!lstatSync(flags.testrailCustomResultFields).isFile()) {
-        throw new Error("Something went wrong. You provided a testrailCustomResultFields path, but jahia-reporter could not access it")
+        throw new Error('Something went wrong. You provided a testrailCustomResultFields path, but jahia-reporter could not access it')
       }
       this.log(`${flags.testrailCustomResultFields}, exists, parsing its content`)
       const rawFile = readFileSync(flags.testrailCustomResultFields, 'utf8')
@@ -241,26 +241,26 @@ class JahiaTestrailReporter extends Command {
       // Get all configured Testrail custom fields for that account
       // Decorate it with value and project details
       this.log('Get all configured custom fields')
-      testrailCustomFields = testrail.getResultFields().map((t) => {
+      testrailCustomFields = testrail.getResultFields().map(t => {
         // See static type list here: https://support.gurock.com/hc/en-us/articles/7077871398036-Result-Fields
         const staticTypes = ['', 'String', 'Integer', 'Text', 'URL', 'Checkbox', 'Dropdown', 'User', 'Date', 'Milestone', 'Step Results', 'Multi-select']
-        let isEnabledOnProject = false;
-        const config = t.configs.forEach((c) => {
+        let isEnabledOnProject = false
+        t.configs.forEach(c => {
           if (c.context.is_global === true || c.context.project_ids.includes(testrailProject.id)) {
             isEnabledOnProject = true
           }
-        })     
+        })
         // Search in the submission to find a match
         return {
           ...t,
           type: staticTypes[t.type_id],
           enabledOnProject: isEnabledOnProject, // Is that custom field valid for the current project
-          value: customFieldsSubmission[t.system_name]
+          value: customFieldsSubmission[t.system_name],
         }
       })
       this.log('The following custom fields are present on testrail:')
-      cli.table(testrailCustomFields, {id: {}, system_name: {}, type: {},  enabledOnProject: {}, value: {}, description: {} })
-      testrailCustomFields = testrailCustomFields.filter((f) => f.enabledOnProject === true)
+      cli.table(testrailCustomFields, {id: {}, system_name: {}, type: {},  enabledOnProject: {}, value: {}, description: {}})
+      testrailCustomFields = testrailCustomFields.filter(f => f.enabledOnProject === true)
     }
 
     // In order to make sure that all the test cases exist in TestRail we need to first make sure all the sections exist
@@ -408,7 +408,7 @@ class JahiaTestrailReporter extends Command {
           status_id = 2
         }
         // const status_id: Status = test.comment === undefined ? Status.Passed : Status.Failed
-        let testResult: any = {
+        const testResult: any = {
           case_id: test.id,
           elapsed: test.time,
           status_id: status_id,
@@ -420,7 +420,7 @@ class JahiaTestrailReporter extends Command {
         this.log(
           `Puhsing to testrail - Title: ${test.title} - case_id: ${test.id} - status_id: ${status_id}`,
         )
-        
+
         // Adding custom fields when applicable
         if (testrailCustomFields.length > 0) {
           testrailCustomFields.forEach(f => {

--- a/src/commands/testrail.ts
+++ b/src/commands/testrail.ts
@@ -18,7 +18,7 @@ import {formatToTimeZone} from 'date-fns-timezone'
 import {JRRun, JRTestfailure} from '../global.type'
 import ingestReport from '../utils/ingest'
 import {cli} from 'cli-ux'
-import {lstatSync, readFileSync} from 'fs'
+import {lstatSync, readFileSync, existsSync} from 'fs'
 
 interface TestWithStatus extends Test {
   status: string;
@@ -229,10 +229,13 @@ class JahiaTestrailReporter extends Command {
     this.log(`Using milestone ${flags.milestone} with id: ${milestone_id}`)
 
     let testrailCustomFields: ResultField[] = []
-    if (flags.testrailCustomResultFields !== undefined) {
+    if (flags.testrailCustomResultFields !== undefined && flags.testrailCustomResultFields !== '') {
       // Parse the provided json file
+      if (!existsSync(flags.testrailCustomResultFields)) {
+        throw new Error(`Something went wrong. The provided path: ${flags.testrailCustomResultFields} does not exist.`)
+      }
       if (!lstatSync(flags.testrailCustomResultFields).isFile()) {
-        throw new Error('Something went wrong. You provided a testrailCustomResultFields path, but jahia-reporter could not access it')
+        throw new Error(`Something went wrong. The provided path: ${flags.testrailCustomResultFields} is not a file`)
       }
       this.log(`${flags.testrailCustomResultFields}, exists, parsing its content`)
       const rawFile = readFileSync(flags.testrailCustomResultFields, 'utf8')

--- a/src/commands/testrail.ts
+++ b/src/commands/testrail.ts
@@ -12,10 +12,13 @@ import {
   Run,
   Status,
   TestRailResult,
+  ResultField,
 } from '../utils/testrail.interface'
 import {formatToTimeZone} from 'date-fns-timezone'
 import {JRRun, JRTestfailure} from '../global.type'
 import ingestReport from '../utils/ingest'
+import { cli } from 'cli-ux'
+import {lstatSync, readFileSync} from 'fs'
 
 interface TestWithStatus extends Test {
   status: string;
@@ -43,6 +46,10 @@ class JahiaTestrailReporter extends Command {
       description: 'TestRail url to submit the results from the report to',
       default: 'https://jahia.testrail.net',
     }),
+    testrailApiKey: flags.string({
+      description: 'TestRail to be used as an alternative to username/password',
+      required: false,
+    }),    
     testrailUsername: flags.string({
       description: 'TestRail username',
       required: true,
@@ -51,6 +58,10 @@ class JahiaTestrailReporter extends Command {
       description: 'TestRail password',
       required: true,
     }),
+    testrailCustomResultFields: flags.string({
+      description: 'Path to a file containing values (in a key:value JSON object) to be added to the result fields',
+      default: '',
+    }),    
     projectName: flags.string({
       char: 'n',
       description: 'TestRail Project name',
@@ -152,7 +163,7 @@ class JahiaTestrailReporter extends Command {
     const testrail = new TestRailClient(
       flags.testrailUrl,
       flags.testrailUsername,
-      flags.testrailPassword,
+      flags.testrailApiKey === undefined ? flags.testrailPassword : flags.testrailApiKey
     )
 
     this.log('Get all testrail projects')
@@ -216,6 +227,41 @@ class JahiaTestrailReporter extends Command {
         testrail.addMilestone(testrailProject.id, flags.milestone).id
     }
     this.log(`Using milestone ${flags.milestone} with id: ${milestone_id}`)
+
+    let testrailCustomFields: ResultField[] = []
+    if (flags.testrailCustomResultFields !== undefined) {
+      // Parse the provided json file
+      if (!lstatSync(flags.testrailCustomResultFields).isFile()) {
+        throw new Error("Something went wrong. You provided a testrailCustomResultFields path, but jahia-reporter could not access it")
+      }
+      this.log(`${flags.testrailCustomResultFields}, exists, parsing its content`)
+      const rawFile = readFileSync(flags.testrailCustomResultFields, 'utf8')
+      const customFieldsSubmission = JSON.parse(rawFile.toString())
+
+      // Get all configured Testrail custom fields for that account
+      // Decorate it with value and project details
+      this.log('Get all configured custom fields')
+      testrailCustomFields = testrail.getResultFields().map((t) => {
+        // See static type list here: https://support.gurock.com/hc/en-us/articles/7077871398036-Result-Fields
+        const staticTypes = ['', 'String', 'Integer', 'Text', 'URL', 'Checkbox', 'Dropdown', 'User', 'Date', 'Milestone', 'Step Results', 'Multi-select']
+        let isEnabledOnProject = false;
+        const config = t.configs.forEach((c) => {
+          if (c.context.is_global === true || c.context.project_ids.includes(testrailProject.id)) {
+            isEnabledOnProject = true
+          }
+        })     
+        // Search in the submission to find a match
+        return {
+          ...t,
+          type: staticTypes[t.type_id],
+          enabledOnProject: isEnabledOnProject, // Is that custom field valid for the current project
+          value: customFieldsSubmission[t.system_name]
+        }
+      })
+      this.log('The following custom fields are present on testrail:')
+      cli.table(testrailCustomFields, {id: {}, system_name: {}, type: {},  enabledOnProject: {}, value: {}, description: {} })
+      testrailCustomFields = testrailCustomFields.filter((f) => f.enabledOnProject === true)
+    }
 
     // In order to make sure that all the test cases exist in TestRail we need to first make sure all the sections exist
     const executedSections: Section[] = []
@@ -362,7 +408,7 @@ class JahiaTestrailReporter extends Command {
           status_id = 2
         }
         // const status_id: Status = test.comment === undefined ? Status.Passed : Status.Failed
-        const testResult: TestRailResult = {
+        let testResult: any = {
           case_id: test.id,
           elapsed: test.time,
           status_id: status_id,
@@ -374,6 +420,13 @@ class JahiaTestrailReporter extends Command {
         this.log(
           `Puhsing to testrail - Title: ${test.title} - case_id: ${test.id} - status_id: ${status_id}`,
         )
+        
+        // Adding custom fields when applicable
+        if (testrailCustomFields.length > 0) {
+          testrailCustomFields.forEach(f => {
+            testResult[f.system_name] = f.value
+          })
+        }
         results.push(testResult)
       }
     }

--- a/src/commands/utils/modules.ts
+++ b/src/commands/utils/modules.ts
@@ -2,9 +2,10 @@ import {Command, flags} from '@oclif/command'
 import * as fs from 'fs'
 import * as path from 'path'
 
-import {UtilsVersions} from '../../global.type'
+import {UtilsVersions, UtilsPlatform} from '../../global.type'
 
 import {getModules} from '../../utils/modules'
+import {getPlatform} from '../../utils/platform'
 
 class JahiaUtilsModule extends Command {
   static description = 'For a provided module, returns the module version, Jahia version and list of installed modules'
@@ -45,10 +46,11 @@ class JahiaUtilsModule extends Command {
 
     const jahiaFullUrl = flags.jahiaUrl.slice(-1) === '/' ? flags.jahiaUrl : flags.jahiaUrl + '/'
     const version: UtilsVersions = getModules(flags.moduleId, dependencies, jahiaFullUrl, flags.jahiaUsername, flags.jahiaPassword)
+    const platform: UtilsPlatform | undefined = getPlatform(jahiaFullUrl, flags.jahiaUsername, flags.jahiaPassword)
 
     fs.writeFileSync(
       path.join(flags.filepath),
-      JSON.stringify(version)
+      JSON.stringify({...version, platform: platform})
     )
   }
 }

--- a/src/global.type.ts
+++ b/src/global.type.ts
@@ -77,6 +77,41 @@ export interface UtilsVersions {
   allModules: JahiaModule[];
 }
 
+export interface UtilsPlatform {
+  jahia: {
+    version: {
+      build: string;
+      buildDate: string;
+      isSnapshot: string;
+      release: string;
+    };
+    database: {
+      type: string;
+      name: string;
+      version: string;
+      driverName: string;
+      driverVersion: string;
+      url: string;
+    };
+    system: {
+      os: {
+        name: string;
+        architecture: string;
+        version: string;
+      };
+      java: {
+        runtimeName: string;
+        runtimeVerison: string;
+        vendor: string;
+        vendorVersion: string;
+      };
+    };
+  };
+  cluster: {
+    isActivated: boolean;
+  };
+}
+
 export interface JMeterTRunTransaction {
   name: string;
   sampleCount?: number;

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,55 @@
+import {SyncRequestClient} from 'ts-sync-request/dist'
+import {Base64} from 'js-base64'
+
+// eslint-disable-next-line max-params
+export const getPlatform = (jahiaUrl: string, jahiaUsername: string, jahiaPassword: string) => {
+  const authHeader = `Basic ${Base64.btoa(jahiaUsername + ':' + jahiaPassword)}`
+
+  // Simple graphql call to fetch the query
+  let response: any = new SyncRequestClient()
+  .addHeader('Content-Type', 'application/json')
+  .addHeader('referer', jahiaUrl)
+  .addHeader('authorization', authHeader)
+  .post(jahiaUrl + 'modules/graphql', {query: '{admin{jahia{version{build buildDate isSnapshot release}database{type name version driverName driverVersion url}system{os{name architecture version}java{runtimeName runtimeVersion vendor vendorVersion}}}cluster{isActivated}}}'})
+
+  if (response.data !== null && response.errors === undefined) {
+    // eslint-disable-next-line no-console
+    console.log('Fetched full details about the platform')
+    return response.data.admin
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('Unable to execute the full GraphQL query to get platform details')
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(response.errors))
+
+  // If there was an error, get only the jahia version. This part of the API
+  response = new SyncRequestClient()
+  .addHeader('Content-Type', 'application/json')
+  .addHeader('referer', jahiaUrl)
+  .addHeader('authorization', authHeader)
+  .post(jahiaUrl + 'modules/graphql', {query: '{admin{jahia{version{build buildDate isSnapshot release}}}}'})
+
+  if (response.data !== null && response.errors === undefined) {
+    // eslint-disable-next-line no-console
+    console.log('Fetched partial details about the platform')
+    return response.data.admin
+  }
+
+  // eslint-disable-next-line no-console
+  console.log('Unable to execute the simplified GraphQL query to get platform details')
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(response.errors))
+
+  // Othwerise return empty data
+  return {
+    jahia: {
+      version: {
+        build: 'UNKNOWN',
+        buildDate: 'UNKNOWN',
+        isSnapshot: 'UNKNOWN',
+        release: 'UNKNOWN',
+      },
+    },
+  }
+}

--- a/src/utils/testrail.interface.ts
+++ b/src/utils/testrail.interface.ts
@@ -30,6 +30,37 @@ export interface Project {
   url: string;
 }
 
+export interface ResultField {
+  id: number;
+  is_active: boolean;
+  type_id: number;
+  name: string;
+  system_name:  string;
+  label:  string;
+  description: string;
+  configs: ResultFieldConfig[];
+  display_order:number;
+  include_all: number;
+  template_ids: number[];
+
+  // Fields added while comparing with the submitted file
+  enabledOnProject: boolean;
+  type: string;
+  value: string;  
+}
+
+export interface ResultFieldConfig {
+  id: number;
+  context: {
+    is_global: boolean;
+    project_ids: number[];
+  };
+  options: {
+    is_required: false;
+    defailt_value: string;
+  }
+}
+
 export interface Suite {
   id: number;
   name: string;

--- a/src/utils/testrail.interface.ts
+++ b/src/utils/testrail.interface.ts
@@ -39,14 +39,14 @@ export interface ResultField {
   label:  string;
   description: string;
   configs: ResultFieldConfig[];
-  display_order:number;
+  display_order: number;
   include_all: number;
   template_ids: number[];
 
   // Fields added while comparing with the submitted file
   enabledOnProject: boolean;
   type: string;
-  value: string;  
+  value: string;
 }
 
 export interface ResultFieldConfig {
@@ -58,7 +58,7 @@ export interface ResultFieldConfig {
   options: {
     is_required: false;
     defailt_value: string;
-  }
+  };
 }
 
 export interface Suite {

--- a/src/utils/testrail.ts
+++ b/src/utils/testrail.ts
@@ -1,5 +1,5 @@
 import {SyncRequestClient} from 'ts-sync-request/dist'
-import {AddCase, PaginatedProjects, Project, PaginatedSections, Section, Suite, PaginatedTests, Test, TestRailResult, AddRun, Run, CaseFields, PaginatedMilestones, Milestone} from './testrail.interface'
+import {AddCase, PaginatedProjects, Project, PaginatedSections, ResultField, Section, Suite, PaginatedTests, Test, TestRailResult, AddRun, Run, CaseFields, PaginatedMilestones, Milestone} from './testrail.interface'
 
 export class TestRailClient {
     public base: string
@@ -41,6 +41,10 @@ export class TestRailClient {
       }
       return []
       // throw new Error("Something went wrong. Can't find any milestone")
+    }
+
+    public getResultFields(): ResultField[] {
+      return this.sendRequest('GET', 'get_result_fields', '') as ResultField[]
     }
 
     public addMilestone(projectId: number, name: string): Milestone {


### PR DESCRIPTION
By providing jahia-reporter with a JSON file containing custom fields values, such fields are then submitted to testrail.

A few details about the implementation:
 - Only submits custom fields enabled for that testrail projects
 - If more fields are present in the json, than what is supported in that Testrail project, they will be ignored
 - A table is displayed in jahia-reporter logs to show which fields are supported

Sample JSON:
```json
{
	"custom_database": "abcd",
	"hello": "world"
}
```

Sample call:
```bash
./bin/run testrail --testrailUsername=CHANGEME --testrailPassword=CHANGEME --sourcePath=/CHANGEME/xml_reports --sourceType=xml --projectName="Sandbox Module" --milestone=Default --defaultRunDescription="This test was executed on Github Actions, https://github.com/Jahia/sandbox/actions/runs/4063578741" --linkRunFile=/CHANGEME/testrail_link --testrailCustomResultFields=/CHANGEME/custom.json
```

Sample output:
```
/PATH/custom.json, exists, parsing its content
Get all configured custom fields
The following custom fields are present on testrail:
Id System name         Type         Enabledonproject Value     Description                                                  
22 custom_database     String       true             abcd      Name of DBMS and version of DBMS which was used for the test 
25 custom_server       String       false            undefined Application Server and version used during the test          
11 custom_step_results Multi-select true             undefined null                                                         
26 custom_testrunlink  URL          true             undefined null                                                         
23 custom_theme        String       false            undefined The DX UI theme (default, jahia-antracite) used in the test  
```