### PR TITLE
TECH-1195: Added an history command

### DIFF
--- a/src/commands/perfs/analyze.ts
+++ b/src/commands/perfs/analyze.ts
@@ -1,52 +1,69 @@
 /* eslint-disable complexity */
 /* eslint-disable max-depth */
-import {Command, flags} from '@oclif/command'
-import {readFileSync} from 'fs'
-import * as fs from 'fs'
-import * as path from 'path'
+import { Command, flags } from '@oclif/command';
+import { readFileSync } from 'fs';
+import * as fs from 'fs';
+import * as path from 'path';
 
-import {JMeterExec, JMeterThresholds, JMeterTRunTransaction, JMeterRunTransaction, JMeterExecAnalysisReport} from '../../global.type'
+import {
+  JMeterExec,
+  JMeterThresholds,
+  JMeterTRunTransaction,
+  JMeterRunTransaction,
+  JMeterExecAnalysisReport,
+} from '../../global.type';
 
 const getRunThreshold = (runName: string, thresholds: JMeterThresholds) => {
   // First use exact match
-  let runThreshold = thresholds.runs.find(t => t.name === runName)
+  let runThreshold = thresholds.runs.find((t) => t.name === runName);
   if (runThreshold !== undefined) {
-    return runThreshold
+    return runThreshold;
   }
 
   // Second, try partial match, returning the first matching record
-  runThreshold = thresholds.runs.find(t => runName.toLowerCase().includes(t.name.toLowerCase()))
+  runThreshold = thresholds.runs.find((t) =>
+    runName.toLowerCase().includes(t.name.toLowerCase()),
+  );
   if (runThreshold !== undefined) {
-    return runThreshold
+    return runThreshold;
   }
 
   // Lastly, try returning "*" match or undefined if none found
-  runThreshold = thresholds.runs.find(t => t.name === '*')
-  return runThreshold
-}
+  runThreshold = thresholds.runs.find((t) => t.name === '*');
+  return runThreshold;
+};
 
-const getTransactionThreshold = (runRransactionName: string, thresholdtransactions: JMeterTRunTransaction[]) => {
-  let transactionThreshold = thresholdtransactions.find(t => t.name === runRransactionName)
+const getTransactionThreshold = (
+  runRransactionName: string,
+  thresholdtransactions: JMeterTRunTransaction[],
+) => {
+  let transactionThreshold = thresholdtransactions.find(
+    (t) => t.name === runRransactionName,
+  );
   if (transactionThreshold !== undefined) {
-    return transactionThreshold
+    return transactionThreshold;
   }
 
-  transactionThreshold = thresholdtransactions.find(t => runRransactionName.toLowerCase().includes(t.name.toLowerCase()))
+  transactionThreshold = thresholdtransactions.find((t) =>
+    runRransactionName.toLowerCase().includes(t.name.toLowerCase()),
+  );
   if (transactionThreshold !== undefined) {
-    return transactionThreshold
+    return transactionThreshold;
   }
 
-  transactionThreshold = thresholdtransactions.find(t => t.name === '*')
-  return transactionThreshold
-}
+  transactionThreshold = thresholdtransactions.find((t) => t.name === '*');
+  return transactionThreshold;
+};
 
 class JahiaAnalyzePerfsReporter extends Command {
-  static description = 'Analyze a runs file against values included in a threshold file.]'
+  static description =
+    'Analyze a runs file against values included in a threshold file.';
 
   static flags = {
-    help: flags.help({char: 'h'}),
+    help: flags.help({ char: 'h' }),
     runsFile: flags.string({
-      description: 'A json file containing the perf report provided by the jmeter container',
+      description:
+        'A json file containing the perf report provided by the jmeter container',
       required: true,
     }),
     thresholdsFile: flags.string({
@@ -54,82 +71,156 @@ class JahiaAnalyzePerfsReporter extends Command {
       required: true,
     }),
     reportFile: flags.string({
-      description: 'A path to store the JSON report that will be generated at the end of the run',
+      description:
+        'A path to store the JSON report that will be generated at the end of the run (full report)',
       default: '',
       required: false,
     }),
-  }
+    verbose: flags.boolean({
+      description: 'Display more log messages',
+      default: false,
+    }),
+    failOnError: flags.boolean({
+      description: 'Should the system send an exit signal in case of failure',
+      default: false,
+    }),
+  };
 
   async run() {
-    const {flags} = this.parse(JahiaAnalyzePerfsReporter)
+    const { flags } = this.parse(JahiaAnalyzePerfsReporter);
 
     if (!fs.existsSync(flags.runsFile)) {
-      this.log(`Unable to read runsFile at: ${flags.runsFile}`)
-      this.exit(1)
+      this.log(`Unable to read runsFile at: ${flags.runsFile}`);
+      this.exit(1);
     }
 
-    const rawFileJmeter = readFileSync(flags.runsFile, 'utf8')
-    const jMeterRuns: JMeterExec = JSON.parse(rawFileJmeter.toString())
+    const rawFileJmeter = readFileSync(flags.runsFile, 'utf8');
+    const jMeterRuns: JMeterExec = JSON.parse(rawFileJmeter.toString());
 
     if (!fs.existsSync(flags.thresholdsFile)) {
-      this.log(`Unable to read thresholdsFile at: ${flags.thresholdsFile}`)
-      this.exit(1)
+      this.log(`Unable to read thresholdsFile at: ${flags.thresholdsFile}`);
+      this.exit(1);
     }
 
-    const rawFileThresholds = readFileSync(flags.thresholdsFile, 'utf8')
-    const jMeterThresholds: JMeterThresholds = JSON.parse(rawFileThresholds.toString())
+    const rawFileThresholds = readFileSync(flags.thresholdsFile, 'utf8');
+    const jMeterThresholds: JMeterThresholds = JSON.parse(
+      rawFileThresholds.toString(),
+    );
 
-    this.log('Starting analysis')
-    this.log('More details about the threshold format can be found at: https://github.com/Jahia/core-perf-test')
+    this.log('Starting analysis');
+    this.log(
+      'More details about the threshold format can be found at: https://github.com/Jahia/core-perf-test',
+    );
 
-    const analysisReport: JMeterExecAnalysisReport[] = []
+    const analysisReport: JMeterExecAnalysisReport[] = [];
     for (const run of jMeterRuns.runs) {
-      const threshold = getRunThreshold(run.name, jMeterThresholds)
+      const threshold = getRunThreshold(run.name, jMeterThresholds);
       if (threshold === undefined) {
-        this.log(`Skipping analysis for run: ${run.name} - No threshold found`)
+        if (flags.verbose) {
+          this.log(
+            `Skipping analysis for run: ${run.name} - No threshold found`,
+          );
+        }
       } else {
-        this.log(`Analyzing run: ${run.name}, using threshold: ${threshold.name}`)
+        this.log(
+          `Analyzing run: ${run.name}, using threshold: ${threshold.name}`,
+        );
         for (let runStat of Object.values(run.statistics)) {
           // Added a check to handle new format for the statistics object used on core-perf-tests
           if (runStat.transaction === undefined) {
-            runStat = Object.values(runStat)[0]
+            runStat = Object.values(runStat)[0];
           }
-          const statThreshold = getTransactionThreshold(runStat.transaction, threshold.transactions)
+          const statThreshold = getTransactionThreshold(
+            runStat.transaction,
+            threshold.transactions,
+          );
           if (statThreshold === undefined) {
-            this.log(`Skipping analysis for run: ${run.name}, transaction: ${runStat.transaction} - No threshold found`)
+            if (flags.verbose) {
+              this.log(
+                `Skipping analysis for run: ${run.name}, transaction: ${runStat.transaction} - No threshold found`,
+              );
+            }
           } else {
             for (const comp of jMeterThresholds.specs) {
-              if (runStat[comp.metric as keyof JMeterRunTransaction] === undefined) {
-                this.log(`Skipping analysis for run: ${run.name}, transaction: ${runStat.transaction} - No value for: ${comp.metric} in the transaction`)
-              } else if (statThreshold[comp.metric as keyof JMeterTRunTransaction] === undefined) {
-                this.log(`Skipping analysis for run: ${run.name}, transaction: ${runStat.transaction} - No threshold found for: ${comp.metric} in the transaction`)
+              if (
+                runStat[comp.metric as keyof JMeterRunTransaction] === undefined
+              ) {
+                if (flags.verbose) {
+                  this.log(
+                    `Skipping analysis for run: ${run.name}, transaction: ${runStat.transaction} - No value for: ${comp.metric} in the transaction`,
+                  );
+                }
+              } else if (
+                statThreshold[comp.metric as keyof JMeterTRunTransaction] ===
+                undefined
+              ) {
+                if (flags.verbose) {
+                  this.log(
+                    `Skipping analysis for run: ${run.name}, transaction: ${runStat.transaction} - No threshold found for: ${comp.metric} in the transaction`,
+                  );
+                }
               } else {
-                const runValue = runStat[comp.metric as keyof JMeterRunTransaction]
-                const thresholdValue = statThreshold[comp.metric as keyof JMeterTRunTransaction]
-                let thresholdError = false
+                const runValue =
+                  runStat[comp.metric as keyof JMeterRunTransaction];
+                const thresholdValue =
+                  statThreshold[comp.metric as keyof JMeterTRunTransaction];
+                let thresholdError = false;
                 if (thresholdValue !== undefined && comp.comparator === 'gt') {
                   if (runValue > thresholdValue) {
-                    thresholdError = true
+                    thresholdError = true;
                   }
-                } else if (thresholdValue !== undefined && comp.comparator === 'gte') {
+                } else if (
+                  thresholdValue !== undefined &&
+                  comp.comparator === 'gte'
+                ) {
                   if (runValue >= thresholdValue) {
-                    thresholdError = true
+                    thresholdError = true;
                   }
-                } else if (thresholdValue !== undefined && comp.comparator === 'lt') {
+                } else if (
+                  thresholdValue !== undefined &&
+                  comp.comparator === 'lt'
+                ) {
                   if (runValue < thresholdValue) {
-                    thresholdError = true
+                    thresholdError = true;
                   }
-                } else if (thresholdValue !== undefined && comp.comparator === 'lte') {
+                } else if (
+                  thresholdValue !== undefined &&
+                  comp.comparator === 'lte'
+                ) {
                   if (runValue <= thresholdValue) {
-                    thresholdError = true
+                    thresholdError = true;
                   }
                 }
                 if (thresholdError) {
-                  this.log(`ERROR: run: ${run.name}, transaction: ${runStat.transaction}, metric: ${comp.metric} is failing threshold => Value: ${runValue} (Operator: ${comp.comparator}) Threshold: ${thresholdValue}`)
-                  analysisReport.push({error: true, run: run.name, transaction: runStat.transaction, metric: comp.metric, comparator: comp.comparator, runValue: runValue, thresholdValue: thresholdValue})
+                  if (flags.verbose) {
+                    this.log(
+                      `ERROR: run: ${run.name}, transaction: ${runStat.transaction}, metric: ${comp.metric} is failing threshold => Value: ${runValue} (Operator: ${comp.comparator}) Threshold: ${thresholdValue}`,
+                    );
+                  }
+                  analysisReport.push({
+                    error: true,
+                    run: run.name,
+                    transaction: runStat.transaction,
+                    metric: comp.metric,
+                    comparator: comp.comparator,
+                    runValue: runValue,
+                    thresholdValue: thresholdValue,
+                  });
                 } else {
-                  this.log(`OK: run: ${run.name}, transaction: ${runStat.transaction}, metric: ${comp.metric} is passing threshold => Value: ${runValue} (Operator: ${comp.comparator}) Threshold: ${thresholdValue}`)
-                  analysisReport.push({error: false, run: run.name, transaction: runStat.transaction, metric: comp.metric, comparator: comp.comparator, runValue: runValue, thresholdValue: thresholdValue})
+                  if (flags.verbose) {
+                    this.log(
+                      `OK: run: ${run.name}, transaction: ${runStat.transaction}, metric: ${comp.metric} is passing threshold => Value: ${runValue} (Operator: ${comp.comparator}) Threshold: ${thresholdValue}`,
+                    );
+                  }
+                  analysisReport.push({
+                    error: false,
+                    run: run.name,
+                    transaction: runStat.transaction,
+                    metric: comp.metric,
+                    comparator: comp.comparator,
+                    runValue: runValue,
+                    thresholdValue: thresholdValue,
+                  });
                 }
               }
             }
@@ -139,22 +230,38 @@ class JahiaAnalyzePerfsReporter extends Command {
     }
 
     if (flags.reportFile !== '') {
-      this.log(`Saving report to: ${flags.reportFile}`)
+      this.log(`Saving report to: ${flags.reportFile}`);
       fs.writeFileSync(
         path.join(flags.reportFile),
-        JSON.stringify(analysisReport)
-      )
+        JSON.stringify({
+          startedAt: jMeterRuns.startedAt,
+          tags: jMeterRuns.tags,
+          analysis: analysisReport,
+        }),
+      );
     }
 
-    if (analysisReport.filter(a => a.error === true).length > 0) {
-      this.log('The following values were failing threshold:')
-      for (const error of analysisReport.filter(a => a.error === true)) {
-        this.log(`ERROR: run: ${error.run}, transaction: ${error.transaction}, metric: ${error.metric} is failing threshold => Value: ${error.runValue} (Operator: ${error.comparator}) Threshold: ${error.thresholdValue}`)
+    if (analysisReport.filter((a) => a.error === true).length > 0) {
+      this.log('The following values were failing threshold:');
+      for (const error of analysisReport.filter((a) => a.error === true)) {
+        this.log(
+          `ERROR: run: ${error.run}, transaction: ${
+            error.transaction
+          }, metric: ${
+            error.metric
+          } is failing threshold => Value: ${Math.round(
+            Number(error.runValue),
+          )} (Operator: ${error.comparator}) Threshold: ${
+            error.thresholdValue
+          }`,
+        );
       }
-      this.log('Exiting with exit code: 1 (failed)')
-      this.exit(1)
+      if (flags.failOnError) {
+        this.log('Exiting with exit code: 1 (failed)');
+        this.exit(1);
+      }
     }
   }
 }
 
-export = JahiaAnalyzePerfsReporter
+export = JahiaAnalyzePerfsReporter;

--- a/src/commands/perfs/history.ts
+++ b/src/commands/perfs/history.ts
@@ -1,0 +1,172 @@
+/* eslint-disable complexity */
+/* eslint-disable max-depth */
+import { Command, flags } from '@oclif/command';
+import { lstatSync, readFileSync } from 'fs';
+import * as fs from 'fs';
+import * as glob from 'glob';
+
+import { cli } from 'cli-ux';
+
+interface TransactionError {
+  run: string;
+  transaction: string;
+  metric: string;
+}
+
+interface ReportAnalysis {
+  error: boolean;
+  run: string;
+  transaction: string;
+  metric: string;
+  comparator: string;
+  runValue: number;
+  thresholdValue: number;
+}
+
+class JahiaAnalyzePerfsReporter extends Command {
+  static description = 'Provide an historical view over multiple run analysis';
+
+  static flags = {
+    help: flags.help({ char: 'h' }),
+    analysisPath: flags.string({
+      description:
+        'A json file containing the perf report provided by the jmeter container',
+      required: true,
+    }),
+    analysisWindow: flags.integer({
+      description: 'Number of historical runs to analyze and display',
+      default: 6,
+      required: false,
+    }),
+    analysisFailureAlert: flags.integer({
+      description:
+        'Will trigger an alert if the last X runs were below threshold for a transaction',
+      default: 2,
+      required: false,
+    }),
+  };
+
+  async run() {
+    const { flags } = this.parse(JahiaAnalyzePerfsReporter);
+
+    if (
+      !fs.existsSync(flags.analysisPath) ||
+      !lstatSync(flags.analysisPath).isDirectory()
+    ) {
+      this.log(`Unable to find the following folder: ${flags.analysisPath}`);
+      this.exit(1);
+    }
+
+    const reportFiles = glob.sync(flags.analysisPath + '/**/*.json', {});
+
+    const reportWindow = reportFiles.sort().slice(-flags.analysisWindow);
+
+    const reports: Array<any> = [];
+    // Load all report files in memory
+    for (const f of reportWindow) {
+      const rawFile = readFileSync(f, 'utf8');
+      const jsonReport = JSON.parse(rawFile);
+      reports.push(jsonReport);
+    }
+
+    // Create an array of all transactions with errors in the report
+    const errors: Array<TransactionError> = [];
+    const runs: Array<string> = [];
+    for (const r of reports) {
+      for (const a of r.analysis.filter(
+        (a: ReportAnalysis) => a.error === true,
+      )) {
+        if (!runs.includes(a.run)) {
+          runs.push(a.run);
+        }
+        if (
+          errors.find(
+            (e) => e.transaction === a.transaction && e.run === a.run,
+          ) === undefined
+        ) {
+          errors.push({
+            run: a.run,
+            transaction: a.transaction,
+            metric: a.metric,
+          });
+        }
+      }
+    }
+
+    // Create a table of all values across the specified window
+    const errorsTable: Array<any> = errors.map((e) => {
+      const transactions = reports.map((r) => {
+        return {
+          startedAt: r.startedAt,
+          analysis: r.analysis.find(
+            (a: ReportAnalysis) =>
+              e.transaction === a.transaction &&
+              e.metric === a.metric &&
+              e.run === a.run,
+          ),
+        };
+      });
+      return {
+        ...e,
+        analysis: transactions,
+      };
+    });
+
+    // Format the data to be displayed in oclif table (https://oclif.io/docs/table)
+    // A bit of dirty data wrangling
+    let triggerFailure = false;
+    for (const run of runs) {
+      this.log(`Displaying errors for run: ${run}`);
+      // Each run gets its own table
+      const currentTransations = errorsTable.filter((e) => e.run === run);
+      const columns: any = {
+        // oclif table configuration
+        transaction: {},
+        metric: {},
+      };
+      // Add one column per report
+      for (const a of currentTransations[0].analysis) {
+        columns[a.startedAt.slice(0, 10)] = {};
+      }
+      columns['Send Alert'] = {};
+      columns['threshold'] = {};
+
+      const formattedTable = errorsTable
+        .filter((e) => e.run === run)
+        .map((e) => {
+          const row: any = {
+            // oclif table row
+            transaction: e.transaction,
+            metric: e.metric,
+          };
+          for (const a of e.analysis) {
+            const cellValue = Math.round(a.analysis.runValue);
+            row[a.startedAt.slice(0, 10)] =
+              a.analysis.error === true ? `${cellValue}*` : cellValue;
+          }
+          const alertWindow = e.analysis.slice(-flags.analysisFailureAlert);
+          const alertCount = alertWindow.reduce(
+            (acc: number, a: any) => acc + (a.analysis.error === true ? 1 : 0),
+            0,
+          );
+          if (alertCount === flags.analysisFailureAlert) {
+            triggerFailure = true;
+          }
+          row['threshold'] =
+            e.analysis[e.analysis.length - 1].analysis.thresholdValue;
+          row['Send Alert'] =
+            alertCount === flags.analysisFailureAlert ? 'YES' : 'NO';
+          return row;
+        });
+      this.log('* (Above threshold)');
+      cli.table(formattedTable, columns);
+    }
+
+    if (triggerFailure) {
+      this.log('Exiting with exit code: 1 (failed)');
+      this.exit(1);
+    }
+  }
+}
+
+export = JahiaAnalyzePerfsReporter;

--- a/src/global.type.ts
+++ b/src/global.type.ts
@@ -61,9 +61,9 @@ export interface ZenCrepesStateNode {
 }
 
 export interface JahiaModule {
-    id: string;
-    name: string;
-    version: string;
+  id: string;
+  name: string;
+  version: string;
 }
 
 export interface UtilsVersions {
@@ -176,6 +176,7 @@ export interface JMeterExec {
   duration: number;
   runs: JMeterRun[];
   startedAt: string;
+  tags: Array<any>;
 }
 
 export interface JMeterExecAnalysisReport {


### PR DESCRIPTION
Taking as an input a folder containing perf runs analysis, this commands display a table containing all of the analysis with errors.

Users can provide a particular windows (the number of analysis to include in the table, the last 6 runs by default) and the number of failures that would trigger an alert (2 by default). 

Sample output:
```
➜  jahia-reporter git:(TECH-1195) ./bin/run perfs:history --analysisPath=/Users/fgerthoffert/GitHub/Jahia/core-perf-test/runs_history/
Displaying errors for run: Jahia Perf at 120mn
* (Above threshold)
Transaction                                      Metric      2023-03-13 2023-03-15 2023-03-20 2023-03-22 2023-03-24 2023-03-27 Send alert Threshold 
E2c View page in edit mode                       pct1ResTime 1029*      1074*      1111*      1110*      1042       1030       NO         1050      
E3-U1b Edit content / Close locked engine+reload pct1ResTime 717        210        1113*      622        731        809        NO         1000      
E3-U1d Edit news entry list page / Save+reload   pct1ResTime 1404       1369       1617*      1626*      1320       1310       NO         1500      
E2c View list page in edit mode                  pct1ResTime 1333       1253       1419*      1406*      1281       1267       NO         1400      
E2a Open homepage in edit (+load config)         pct2ResTime 1362       1339       1556*      1346       1316       1505*      NO         1500      
E3-U1a Edit news entry / Preview                 pct2ResTime 2234       2198       2436       2765*      2024       2542*      NO         2500      
E3-C6b Add main content / Save+reload            pct1ResTime 1442       1388       1393       1418       1338       1519*      NO         1500      
P2 WebSocket reload check (X)                    errorCount  0          0          0          0          0          1*         NO         0 
```