### PR TITLE
Cleaned up usage of JSON reporting to handle skipped or pending

### DIFF
--- a/src/global.type.ts
+++ b/src/global.type.ts
@@ -15,6 +15,7 @@ export interface JRTestsuite {
   errors?: number;
   failures: number;
   skipped: number;
+  pending: number;
   timestamp: string;
   time: number;
   tests: JRTestcase[];
@@ -26,6 +27,7 @@ export interface JRReport {
   tests: number;
   failures: number;
   skipped: number;
+  pending: number;
   time: number;
   testsuites: JRTestsuite[];
 }
@@ -35,6 +37,7 @@ export interface JRRun {
   tests: number;
   failures: number;
   skipped: number;
+  pending: number;
   time: number;
   reports: JRReport[];
 }

--- a/src/utils/ingest/parse-json-perf-report.ts
+++ b/src/utils/ingest/parse-json-perf-report.ts
@@ -13,6 +13,7 @@ export const parseJsonPerf = (rawAnalysis: JMeterExecAnalysisReport[]): JRRun =>
       tests: rawAnalysis.filter(a => a.run === run).length,
       failures: rawAnalysis.filter(a => a.run === run && a.error === true).length,
       skipped: 0,
+      pending: 0,
       time: 0,
       testsuites: transactions.map(t => {
         const metrics = rawAnalysis.filter(a => a.run === run && a.transaction === t).map(a => a.metric)
@@ -20,6 +21,7 @@ export const parseJsonPerf = (rawAnalysis: JMeterExecAnalysisReport[]): JRRun =>
           name: t,
           failures: rawAnalysis.filter(a => a.run === run && a.transaction === t && a.error === true).length,
           skipped: 0,
+          pending: 0,
           timestamp: '',
           time: 0,
           tests: metrics.map(m => {
@@ -29,6 +31,7 @@ export const parseJsonPerf = (rawAnalysis: JMeterExecAnalysisReport[]): JRRun =>
               time: 0,
               status: metricTest !== undefined && metricTest.error === true ? 'FAIL' : 'PASS',
               skipped: 0,
+              pending: 0,
               failures: metricTest !== undefined && metricTest.error === true ? [{text: `ERROR: run: ${metricTest.run}, transaction: ${metricTest.transaction}, metric: ${metricTest.metric} is failing threshold => Value: ${metricTest.runValue} (Operator: ${metricTest.comparator}) Threshold: ${metricTest.thresholdValue}`}] : [],
             }
           }),
@@ -42,6 +45,7 @@ export const parseJsonPerf = (rawAnalysis: JMeterExecAnalysisReport[]): JRRun =>
     tests: rawAnalysis.length,
     failures: rawAnalysis.filter(a => a.error).length,
     skipped: 0,
+    pending: 0,
     time: 0,
     reports: reports,
   }

--- a/src/utils/ingest/parse-json-report.ts
+++ b/src/utils/ingest/parse-json-report.ts
@@ -33,7 +33,7 @@ const mochaParser = (rawReports: any[]): JRRun => {
             return {
               name: mochaTest.title,
               time: mochaTest.duration,
-              status: mochaTest.pass === true ? 'PASS' : 'FAIL',
+              status,
               failures: [{text: mochaTest.err.estack}],
               steps: mochaTest.code,
             }

--- a/src/utils/ingest/parse-json-report.ts
+++ b/src/utils/ingest/parse-json-report.ts
@@ -2,70 +2,6 @@ import {basename} from 'path'
 
 import {JRRun, JRTestsuite, JRReport} from '../../global.type'
 
-const legacyParser = (rawReports: any[]): JRRun => {
-  // Each file has one single report and one single suite, different in that from the xml report
-  const suites: JRTestsuite[] = rawReports
-  .filter((rc: any) => rc.content.stats !== undefined && rc.content.tests !== undefined)
-  .reduce((acc: any, rawContent: any) => {
-    // Primary tests are the tests reported in the tests array of the report
-    const primaryTests = rawContent.content.tests.map((t: any) => {
-      return {
-        name: t.title,
-        steps: t.body,
-        time: Math.round(t.duration / 1000), // Time is in ms, converting to s
-        status: Object.values(t.err).length === 0 ? 'PASS' : 'FAIL',
-        failures: Object.values(t.err).length === 0 ? [] : [{
-          text: JSON.stringify(t.err),
-        }],
-        skipped: t.skipped === undefined ? 0 : Math.round(t.skipped),
-      }
-    })
-
-    // In some situations (for example after each failing, we'd want to add those into the list of failed tests)
-    const otherFailed = rawContent.content.failures
-    .filter((t: any) => primaryTests.find((pt: any) => pt.name === t.title) === undefined)
-    .map((t: any) => {
-      return {
-        name: t.title,
-        time: Math.round(t.duration / 1000), // Time is in ms, converting to s
-        status: 'FAIL',
-        failures: Object.values(t.err).length === 0 ? [] : [{
-          text: JSON.stringify(t.err),
-        }],
-        skipped: t.skipped === undefined ? 0 : Math.round(t.skipped),
-      }
-    })
-
-    const suiteName = rawContent.content.tests[0] === undefined ? rawContent.content.failures[0].suite : rawContent.content.tests[0].suite
-    const parsedSuite: any = [{
-      name: suiteName + ' (' + basename(rawContent.filepath) + ')',
-      failures: rawContent.content.stats.failures,
-      skipped: rawContent.content.stats.skipped === undefined ? 0 : rawContent.content.stats.skipped,
-      timestamp: rawContent.content.stats.start,
-      time: Math.round(rawContent.content.stats.duration / 1000), // Time is in ms, converting to s
-      tests: [...primaryTests, ...otherFailed],
-    }]
-
-    return [...acc, ...parsedSuite]
-  }, [])
-
-  // Once all files are concatenated, generate an aggregate of all of the reports below
-  return {
-    tests: suites.map(r => r.tests.length).reduce((acc, count) => acc + count, 0),
-    failures: suites.map(r => r.failures).reduce((acc, count) => acc + count, 0),
-    skipped: suites.map(r => r.skipped).reduce((acc, count) => acc + count, 0),
-    time: suites.map(r => r.time).reduce((acc, count) => acc + count, 0),
-    reports: [{
-      name: 'Mocha JSON Report',
-      tests: suites.map(r => r.tests.length).reduce((acc, count) => acc + count, 0),
-      failures: suites.map(r => r.failures).reduce((acc, count) => acc + count, 0),
-      skipped: suites.map(r => r.skipped).reduce((acc, count) => acc + count, 0),
-      time: suites.map(r => r.time).reduce((acc, count) => acc + count, 0),
-      testsuites: suites,
-    }],
-  }
-}
-
 const mochaParser = (rawReports: any[]): JRRun => {
   // Each file has one single report and one single suite, different in that from the xml report
   const reports: JRReport[] = rawReports
@@ -75,6 +11,8 @@ const mochaParser = (rawReports: any[]): JRRun => {
       name: basename(rawContent.filepath),
       tests: rawContent.content.stats.tests,
       failures: rawContent.content.stats.failures,
+      skipped: rawContent.content.stats.skipped,
+      pending: rawContent.content.stats.pending,
       timestamp: rawContent.content.stats.start,
       time: Math.round(rawContent.content.stats.duration / 1000), // Time is in ms, converting to s
       testsuites: rawContent.content.results.map((mochaReport: any) => {
@@ -82,9 +20,16 @@ const mochaParser = (rawReports: any[]): JRRun => {
           name: mochaReport.suites[0].title,
           failures: mochaReport.suites[0].failures.length,
           skipped: mochaReport.suites[0].skipped.length,
+          pending: mochaReport.suites[0].pending.length,
           time: mochaReport.suites[0].duration,
           timestamp: '',
           tests: mochaReport.suites[0].tests.map((mochaTest: any) => {
+            let status = 'PASS'
+            if (mochaTest.fail === true) {
+              status = 'FAIL'
+            } else if (mochaTest.pending === true) {
+              status = 'PENDING'
+            }
             return {
               name: mochaTest.title,
               time: mochaTest.duration,
@@ -105,6 +50,7 @@ const mochaParser = (rawReports: any[]): JRRun => {
     tests: reports.map(r => r.tests).reduce((acc, count) => acc + count, 0),
     failures: reports.map(r => r.failures).reduce((acc, count) => acc + count, 0),
     skipped: reports.map(r => r.skipped).reduce((acc, count) => acc + count, 0),
+    pending: reports.map(r => r.pending).reduce((acc, count) => acc + count, 0),
     time: reports.map(r => r.time).reduce((acc, count) => acc + count, 0),
     reports: reports,
   }
@@ -112,12 +58,6 @@ const mochaParser = (rawReports: any[]): JRRun => {
 
 // Take an array of junit json files, return a javascript representation of the files content
 export const parseJson = (rawReports: any[]): JRRun => {
-  if (rawReports.filter((rc: any) => rc.content.meta !== undefined).length > 0) {
-    // eslint-disable-next-line no-console
-    console.log('Proceeding with mocha parser')
-    return mochaParser(rawReports)
-  }
-  // eslint-disable-next-line no-console
-  console.log('Proceeding with legacy parser')
-  return legacyParser(rawReports)
+  console.log('Proceeding with mocha parser')
+  return mochaParser(rawReports) 
 }

--- a/src/utils/ingest/parse-xml-report.ts
+++ b/src/utils/ingest/parse-xml-report.ts
@@ -12,6 +12,9 @@ const buildTest = (xmlTests: any) => {
     if (t.elements !== undefined && t.elements.length > 0 && t.elements[0].name !== undefined && t.elements[0].name === 'skipped') {
       status = 'SKIP'
     }
+    if (t.elements !== undefined && t.elements.length > 0 && t.elements[0].name !== undefined && t.elements[0].name === 'pending') {
+      status = 'PENDING'
+    }    
     return {
       ...t.attributes,
       time: Math.round(t.attributes.time),
@@ -35,6 +38,7 @@ const buildSuites = (xmlSuites: any, testFilename: string) => {
       errors: Math.round(s.attributes.errors),
       failures: Math.round(s.attributes.failures) < 0 ? 0 : Math.round(s.attributes.failures),
       skipped: s.attributes.skipped === undefined ? 0 : Math.round(s.attributes.skipped),
+      pending: s.attributes.pending === undefined ? 0 : Math.round(s.attributes.pending),
       testsCount: Math.round(s.attributes.tests),
       time: Math.round(s.attributes.time),
       tests: s.elements === undefined ? [] : buildTest(s.elements.filter((t: any) => t.name === 'testcase')),
@@ -64,6 +68,7 @@ export const parseXML = (rawReports: any[]): JRRun => {
         tests: Math.round(i.attributes.tests),
         failures: Math.round(i.attributes.failures) < 0 ? 0 : Math.round(i.attributes.failures),
         skipped: i.attributes.skipped === undefined ? 0 : Math.round(i.attributes.skipped),
+        pending: i.attributes.pending === undefined ? 0 : Math.round(i.attributes.pending),
         time: Math.round(i.attributes.time),
         // testsuites: buildSuites(i.elements),
         testsuites: testsuites,
@@ -78,6 +83,7 @@ export const parseXML = (rawReports: any[]): JRRun => {
     tests: reports.map(r => r.tests).reduce((acc, count) => acc + count, 0),
     failures: reports.map(r => r.failures).reduce((acc, count) => acc + count, 0),
     skipped: reports.map(r => r.skipped).reduce((acc, count) => acc + count, 0),
+    pending: reports.map(r => r.pending).reduce((acc, count) => acc + count, 0),
     time: reports.map(r => r.time).reduce((acc, count) => acc + count, 0),
     reports: reports,
   }

--- a/test/__snapshots__/ingest.test.ts.snap
+++ b/test/__snapshots__/ingest.test.ts.snap
@@ -3,16 +3,19 @@
 exports[`Test report ingestion JMeter Perf Analysis JSON 1`] = `
 Object {
   "failures": 10,
+  "pending": 0,
   "reports": Array [
     Object {
       "failures": 3,
       "name": "Jahia Perf at 15mn",
+      "pending": 0,
       "skipped": 0,
       "tests": 9,
       "testsuites": Array [
         Object {
           "failures": 1,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -22,6 +25,7 @@ Object {
                 },
               ],
               "name": "sampleCount",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -29,6 +33,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "errorCount",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -36,6 +41,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -47,6 +53,7 @@ Object {
         Object {
           "failures": 1,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -56,6 +63,7 @@ Object {
                 },
               ],
               "name": "sampleCount",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -63,6 +71,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "errorCount",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -70,6 +79,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -81,6 +91,7 @@ Object {
         Object {
           "failures": 1,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -90,6 +101,7 @@ Object {
                 },
               ],
               "name": "sampleCount",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -97,6 +109,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "errorCount",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -104,6 +117,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -115,6 +129,7 @@ Object {
         Object {
           "failures": 1,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -124,6 +139,7 @@ Object {
                 },
               ],
               "name": "sampleCount",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -131,6 +147,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "errorCount",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -138,6 +155,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -149,6 +167,7 @@ Object {
         Object {
           "failures": 1,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -158,6 +177,7 @@ Object {
                 },
               ],
               "name": "sampleCount",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -165,6 +185,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "errorCount",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -172,6 +193,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -183,6 +205,7 @@ Object {
         Object {
           "failures": 1,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -192,6 +215,7 @@ Object {
                 },
               ],
               "name": "sampleCount",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -199,6 +223,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "errorCount",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -206,6 +231,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -217,6 +243,7 @@ Object {
         Object {
           "failures": 1,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -226,6 +253,7 @@ Object {
                 },
               ],
               "name": "sampleCount",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -233,6 +261,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "errorCount",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -240,6 +269,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -251,6 +281,7 @@ Object {
         Object {
           "failures": 1,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -260,6 +291,7 @@ Object {
                 },
               ],
               "name": "sampleCount",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -267,6 +299,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "errorCount",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -274,6 +307,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -285,6 +319,7 @@ Object {
         Object {
           "failures": 1,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -294,6 +329,7 @@ Object {
                 },
               ],
               "name": "sampleCount",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -301,6 +337,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "errorCount",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -308,6 +345,7 @@ Object {
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -322,17 +360,20 @@ Object {
     Object {
       "failures": 1,
       "name": "Jahia Perf at 30mn",
+      "pending": 0,
       "skipped": 0,
       "tests": 54,
       "testsuites": Array [
         Object {
           "failures": 0,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -344,11 +385,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9b Publish list page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -360,11 +403,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -376,11 +421,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -392,11 +439,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C4 Add content / Open content selector",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -408,11 +457,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2b Navigate in side-panel tree",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -424,11 +475,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7a Add news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -440,11 +493,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7b Add news entry / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -456,11 +511,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9a Publish list page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -472,11 +529,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1b Edit content / Close locked engine+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -488,11 +547,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -504,11 +565,13 @@ Object {
         Object {
           "failures": 0,
           "name": "P1 Background Workflow polling",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -520,11 +583,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -536,11 +601,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -552,11 +619,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8b Publish page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -568,11 +637,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -584,11 +655,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -600,11 +673,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -616,11 +691,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C2 View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -632,11 +709,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E4 Logout",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -648,11 +727,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E1 Login/Dashboard",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -664,11 +745,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -680,11 +763,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit news entry list page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -696,11 +781,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -712,11 +799,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -728,11 +817,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -744,11 +835,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2b Publish update / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -760,11 +853,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -776,11 +871,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -792,11 +889,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1b Add page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -808,11 +907,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C6a Add main content / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -824,11 +925,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -840,11 +943,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View list page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -856,11 +961,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -872,11 +979,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -888,11 +997,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2c Publish update / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -904,11 +1015,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2a Open homepage in edit (+load config)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -920,11 +1033,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1a Add page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -936,11 +1051,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -952,11 +1069,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8a Publish page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -968,11 +1087,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -984,11 +1105,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1 View homepage in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1000,11 +1123,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1016,11 +1141,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1a Login/homepage",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1032,11 +1159,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1048,11 +1177,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit rich text page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1064,11 +1195,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1080,6 +1213,7 @@ Object {
         Object {
           "failures": 1,
           "name": "P2 WebSocket reload check (X)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -1089,6 +1223,7 @@ Object {
                 },
               ],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -1100,11 +1235,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1116,11 +1253,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1132,11 +1271,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1148,11 +1289,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1164,11 +1307,13 @@ Object {
         Object {
           "failures": 0,
           "name": "Total",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1180,11 +1325,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1199,17 +1346,20 @@ Object {
     Object {
       "failures": 1,
       "name": "Jahia Perf at 45mn",
+      "pending": 0,
       "skipped": 0,
       "tests": 55,
       "testsuites": Array [
         Object {
           "failures": 0,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1221,11 +1371,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9b Publish list page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1237,11 +1389,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1253,11 +1407,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1269,11 +1425,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C4 Add content / Open content selector",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1285,11 +1443,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2b Navigate in side-panel tree",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1301,11 +1461,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7a Add news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1317,11 +1479,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7b Add news entry / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1333,11 +1497,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9a Publish list page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1349,11 +1515,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1b Edit content / Close locked engine+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1365,11 +1533,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1381,11 +1551,13 @@ Object {
         Object {
           "failures": 0,
           "name": "P1 Background Workflow polling",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1397,11 +1569,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1413,11 +1587,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1429,11 +1605,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8b Publish page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1445,11 +1623,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1461,11 +1641,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1477,11 +1659,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1493,11 +1677,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C2 View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1509,11 +1695,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E4 Logout",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1525,11 +1713,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E1 Login/Dashboard",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1541,11 +1731,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1557,11 +1749,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit news entry list page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1573,11 +1767,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1589,11 +1785,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1605,11 +1803,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1621,11 +1821,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2b Publish update / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1637,11 +1839,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1653,11 +1857,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1669,11 +1875,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1b Add page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1685,11 +1893,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C6a Add main content / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1701,11 +1911,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1717,11 +1929,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View list page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1733,11 +1947,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1749,11 +1965,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1765,11 +1983,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2c Publish update / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1781,11 +2001,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2a Open homepage in edit (+load config)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1797,11 +2019,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1a Add page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1813,11 +2037,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1829,11 +2055,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8a Publish page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1845,11 +2073,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1861,11 +2091,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1 View homepage in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1877,11 +2109,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1893,11 +2127,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1a Login/homepage",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1909,11 +2145,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1925,11 +2163,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit rich text page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1941,11 +2181,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1957,11 +2199,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1c Edit content / Add new tag",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -1973,6 +2217,7 @@ Object {
         Object {
           "failures": 1,
           "name": "P2 WebSocket reload check (X)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -1982,6 +2227,7 @@ Object {
                 },
               ],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -1993,11 +2239,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2009,11 +2257,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2025,11 +2275,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2041,11 +2293,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2057,11 +2311,13 @@ Object {
         Object {
           "failures": 0,
           "name": "Total",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2073,11 +2329,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2092,17 +2350,20 @@ Object {
     Object {
       "failures": 1,
       "name": "Jahia Perf at 60mn",
+      "pending": 0,
       "skipped": 0,
       "tests": 55,
       "testsuites": Array [
         Object {
           "failures": 0,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2114,11 +2375,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9b Publish list page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2130,11 +2393,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2146,11 +2411,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2162,11 +2429,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C4 Add content / Open content selector",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2178,11 +2447,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2b Navigate in side-panel tree",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2194,11 +2465,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7a Add news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2210,11 +2483,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7b Add news entry / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2226,11 +2501,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9a Publish list page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2242,11 +2519,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1b Edit content / Close locked engine+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2258,11 +2537,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2274,11 +2555,13 @@ Object {
         Object {
           "failures": 0,
           "name": "P1 Background Workflow polling",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2290,11 +2573,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2306,11 +2591,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2322,11 +2609,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8b Publish page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2338,11 +2627,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2354,11 +2645,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2370,11 +2663,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2386,11 +2681,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C2 View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2402,11 +2699,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E4 Logout",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2418,11 +2717,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E1 Login/Dashboard",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2434,11 +2735,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2450,11 +2753,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit news entry list page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2466,11 +2771,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2482,11 +2789,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2498,11 +2807,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2514,11 +2825,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2b Publish update / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2530,11 +2843,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2546,11 +2861,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2562,11 +2879,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1b Add page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2578,11 +2897,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C6a Add main content / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2594,11 +2915,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2610,11 +2933,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View list page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2626,11 +2951,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2642,11 +2969,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2658,11 +2987,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2c Publish update / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2674,11 +3005,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2a Open homepage in edit (+load config)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2690,11 +3023,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1a Add page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2706,11 +3041,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2722,11 +3059,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8a Publish page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2738,11 +3077,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2754,11 +3095,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1 View homepage in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2770,11 +3113,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2786,11 +3131,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1a Login/homepage",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2802,11 +3149,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2818,11 +3167,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit rich text page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2834,11 +3185,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2850,11 +3203,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1c Edit content / Add new tag",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2866,6 +3221,7 @@ Object {
         Object {
           "failures": 1,
           "name": "P2 WebSocket reload check (X)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -2875,6 +3231,7 @@ Object {
                 },
               ],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -2886,11 +3243,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2902,11 +3261,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2918,11 +3279,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2934,11 +3297,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2950,11 +3315,13 @@ Object {
         Object {
           "failures": 0,
           "name": "Total",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2966,11 +3333,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -2985,17 +3354,20 @@ Object {
     Object {
       "failures": 1,
       "name": "Jahia Perf at 75mn",
+      "pending": 0,
       "skipped": 0,
       "tests": 55,
       "testsuites": Array [
         Object {
           "failures": 0,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3007,11 +3379,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9b Publish list page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3023,11 +3397,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3039,11 +3415,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3055,11 +3433,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C4 Add content / Open content selector",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3071,11 +3451,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2b Navigate in side-panel tree",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3087,11 +3469,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7a Add news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3103,11 +3487,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7b Add news entry / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3119,11 +3505,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9a Publish list page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3135,11 +3523,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1b Edit content / Close locked engine+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3151,11 +3541,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3167,11 +3559,13 @@ Object {
         Object {
           "failures": 0,
           "name": "P1 Background Workflow polling",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3183,11 +3577,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3199,11 +3595,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3215,11 +3613,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8b Publish page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3231,11 +3631,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3247,11 +3649,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3263,11 +3667,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3279,11 +3685,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C2 View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3295,11 +3703,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E4 Logout",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3311,11 +3721,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E1 Login/Dashboard",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3327,11 +3739,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3343,11 +3757,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit news entry list page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3359,11 +3775,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3375,11 +3793,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3391,11 +3811,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3407,11 +3829,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2b Publish update / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3423,11 +3847,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3439,11 +3865,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3455,11 +3883,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1b Add page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3471,11 +3901,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C6a Add main content / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3487,11 +3919,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3503,11 +3937,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View list page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3519,11 +3955,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3535,11 +3973,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3551,11 +3991,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2c Publish update / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3567,11 +4009,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2a Open homepage in edit (+load config)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3583,11 +4027,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1a Add page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3599,11 +4045,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3615,11 +4063,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8a Publish page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3631,11 +4081,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3647,11 +4099,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1 View homepage in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3663,11 +4117,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3679,11 +4135,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1a Login/homepage",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3695,11 +4153,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3711,11 +4171,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit rich text page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3727,11 +4189,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3743,11 +4207,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1c Edit content / Add new tag",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3759,6 +4225,7 @@ Object {
         Object {
           "failures": 1,
           "name": "P2 WebSocket reload check (X)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -3768,6 +4235,7 @@ Object {
                 },
               ],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -3779,11 +4247,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3795,11 +4265,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3811,11 +4283,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3827,11 +4301,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3843,11 +4319,13 @@ Object {
         Object {
           "failures": 0,
           "name": "Total",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3859,11 +4337,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3878,17 +4358,20 @@ Object {
     Object {
       "failures": 1,
       "name": "Jahia Perf at 90mn",
+      "pending": 0,
       "skipped": 0,
       "tests": 55,
       "testsuites": Array [
         Object {
           "failures": 0,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3900,11 +4383,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9b Publish list page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3916,11 +4401,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3932,11 +4419,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3948,11 +4437,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C4 Add content / Open content selector",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3964,11 +4455,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2b Navigate in side-panel tree",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3980,11 +4473,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7a Add news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -3996,11 +4491,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7b Add news entry / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4012,11 +4509,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9a Publish list page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4028,11 +4527,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1b Edit content / Close locked engine+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4044,11 +4545,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4060,11 +4563,13 @@ Object {
         Object {
           "failures": 0,
           "name": "P1 Background Workflow polling",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4076,11 +4581,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4092,11 +4599,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4108,11 +4617,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8b Publish page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4124,11 +4635,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4140,11 +4653,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4156,11 +4671,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4172,11 +4689,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C2 View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4188,11 +4707,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E4 Logout",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4204,11 +4725,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E1 Login/Dashboard",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4220,11 +4743,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4236,11 +4761,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit news entry list page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4252,11 +4779,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4268,11 +4797,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4284,11 +4815,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4300,11 +4833,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2b Publish update / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4316,11 +4851,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4332,11 +4869,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4348,11 +4887,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1b Add page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4364,11 +4905,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C6a Add main content / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4380,11 +4923,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4396,11 +4941,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View list page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4412,11 +4959,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4428,11 +4977,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4444,11 +4995,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2c Publish update / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4460,11 +5013,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2a Open homepage in edit (+load config)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4476,11 +5031,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1a Add page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4492,11 +5049,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4508,11 +5067,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8a Publish page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4524,11 +5085,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4540,11 +5103,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1 View homepage in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4556,11 +5121,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4572,11 +5139,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1a Login/homepage",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4588,11 +5157,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4604,11 +5175,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit rich text page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4620,11 +5193,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4636,11 +5211,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1c Edit content / Add new tag",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4652,6 +5229,7 @@ Object {
         Object {
           "failures": 1,
           "name": "P2 WebSocket reload check (X)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -4661,6 +5239,7 @@ Object {
                 },
               ],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -4672,11 +5251,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4688,11 +5269,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4704,11 +5287,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4720,11 +5305,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4736,11 +5323,13 @@ Object {
         Object {
           "failures": 0,
           "name": "Total",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4752,11 +5341,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4771,17 +5362,20 @@ Object {
     Object {
       "failures": 1,
       "name": "Jahia Perf at 105mn",
+      "pending": 0,
       "skipped": 0,
       "tests": 55,
       "testsuites": Array [
         Object {
           "failures": 0,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4793,11 +5387,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9b Publish list page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4809,11 +5405,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4825,11 +5423,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4841,11 +5441,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C4 Add content / Open content selector",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4857,11 +5459,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2b Navigate in side-panel tree",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4873,11 +5477,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7a Add news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4889,11 +5495,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7b Add news entry / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4905,11 +5513,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9a Publish list page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4921,11 +5531,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1b Edit content / Close locked engine+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4937,11 +5549,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4953,11 +5567,13 @@ Object {
         Object {
           "failures": 0,
           "name": "P1 Background Workflow polling",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4969,11 +5585,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -4985,11 +5603,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5001,11 +5621,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8b Publish page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5017,11 +5639,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5033,11 +5657,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5049,11 +5675,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5065,11 +5693,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C2 View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5081,11 +5711,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E4 Logout",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5097,11 +5729,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E1 Login/Dashboard",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5113,11 +5747,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5129,11 +5765,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit news entry list page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5145,11 +5783,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5161,11 +5801,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5177,11 +5819,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5193,11 +5837,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2b Publish update / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5209,11 +5855,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5225,11 +5873,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5241,11 +5891,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1b Add page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5257,11 +5909,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C6a Add main content / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5273,11 +5927,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5289,11 +5945,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View list page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5305,11 +5963,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5321,11 +5981,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5337,11 +5999,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2c Publish update / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5353,11 +6017,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2a Open homepage in edit (+load config)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5369,11 +6035,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1a Add page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5385,11 +6053,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5401,11 +6071,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8a Publish page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5417,11 +6089,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5433,11 +6107,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1 View homepage in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5449,11 +6125,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5465,11 +6143,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1a Login/homepage",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5481,11 +6161,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5497,11 +6179,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit rich text page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5513,11 +6197,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5529,11 +6215,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1c Edit content / Add new tag",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5545,6 +6233,7 @@ Object {
         Object {
           "failures": 1,
           "name": "P2 WebSocket reload check (X)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -5554,6 +6243,7 @@ Object {
                 },
               ],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -5565,11 +6255,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5581,11 +6273,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5597,11 +6291,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5613,11 +6309,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5629,11 +6327,13 @@ Object {
         Object {
           "failures": 0,
           "name": "Total",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5645,11 +6345,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5664,17 +6366,20 @@ Object {
     Object {
       "failures": 1,
       "name": "Jahia Perf at 120mn",
+      "pending": 0,
       "skipped": 0,
       "tests": 55,
       "testsuites": Array [
         Object {
           "failures": 0,
           "name": "E3-C6b Add main content / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5686,11 +6391,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9b Publish list page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5702,11 +6409,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5718,11 +6427,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5734,11 +6445,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C4 Add content / Open content selector",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5750,11 +6463,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2b Navigate in side-panel tree",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5766,11 +6481,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7a Add news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5782,11 +6499,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C7b Add news entry / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5798,11 +6517,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C9a Publish list page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5814,11 +6535,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1b Edit content / Close locked engine+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5830,11 +6553,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5846,11 +6571,13 @@ Object {
         Object {
           "failures": 0,
           "name": "P1 Background Workflow polling",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5862,11 +6589,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View internal link page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5878,11 +6607,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5894,11 +6625,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8b Publish page / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5910,11 +6643,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5926,11 +6661,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3d Search-did you mean (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5942,11 +6679,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2a View news entry in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5958,11 +6697,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C2 View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5974,11 +6715,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E4 Logout",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -5990,11 +6733,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E1 Login/Dashboard",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6006,11 +6751,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6022,11 +6769,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit news entry list page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6038,11 +6787,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6054,11 +6805,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6070,11 +6823,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2d Download internal link (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6086,11 +6841,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2b Publish update / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6102,11 +6859,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6118,11 +6877,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View list page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6134,11 +6895,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1b Add page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6150,11 +6913,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C6a Add main content / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6166,11 +6931,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6182,11 +6949,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View list page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6198,11 +6967,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3a Search few results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6214,11 +6985,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View page in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6230,11 +7003,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U2c Publish update / Queue publish job+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6246,11 +7021,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2a Open homepage in edit (+load config)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6262,11 +7039,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C1a Add page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6278,11 +7057,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3c Paginate search result (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6294,11 +7075,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-C8a Publish page / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6310,11 +7093,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2 View query page in live mode (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6326,11 +7111,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1 View homepage in live mode (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6342,11 +7129,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6358,11 +7147,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L1a Login/homepage",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6374,11 +7165,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Open engine",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6390,11 +7183,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1d Edit rich text page / Save+reload",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6406,11 +7201,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E2c View page in edit mode",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6422,11 +7219,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1c Edit content / Add new tag",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6438,6 +7237,7 @@ Object {
         Object {
           "failures": 1,
           "name": "P2 WebSocket reload check (X)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -6447,6 +7247,7 @@ Object {
                 },
               ],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "FAIL",
               "time": 0,
@@ -6458,11 +7259,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (guest)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6474,11 +7277,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L2b Paginate list/query (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6490,11 +7295,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit news entry / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6506,11 +7313,13 @@ Object {
         Object {
           "failures": 0,
           "name": "E3-U1a Edit rich text / Preview",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6522,11 +7331,13 @@ Object {
         Object {
           "failures": 0,
           "name": "Total",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6538,11 +7349,13 @@ Object {
         Object {
           "failures": 0,
           "name": "L3b Search many results (auth)",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
               "failures": Array [],
               "name": "pct2ResTime",
+              "pending": 0,
               "skipped": 0,
               "status": "PASS",
               "time": 0,
@@ -6564,12 +7377,14 @@ Object {
 exports[`Test report ingestion JUnit XML 1`] = `
 Object {
   "failures": 9,
+  "pending": 0,
   "reports": Array [
     Object {
       "errors": "2",
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.accordion.tests.FormsAccordionTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 2,
       "testsuites": Array [
@@ -6578,6 +7393,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.accordion.tests.FormsAccordionTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -6612,6 +7428,7 @@ Object {
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormCreationTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 10,
       "testsuites": Array [
@@ -6620,6 +7437,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormCreationTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -6706,6 +7524,7 @@ Object {
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormDatatableTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 2,
       "testsuites": Array [
@@ -6714,6 +7533,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormDatatableTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -6744,6 +7564,7 @@ Object {
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormDeletionTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 2,
       "testsuites": Array [
@@ -6752,6 +7573,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormDeletionTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -6782,6 +7604,7 @@ Object {
       "failures": 6,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormExportTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 6,
       "testsuites": Array [
@@ -6790,6 +7613,7 @@ Object {
           "failures": 6,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormExportTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -6860,6 +7684,7 @@ Object {
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormImportTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 6,
       "testsuites": Array [
@@ -6868,6 +7693,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormImportTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -6926,6 +7752,7 @@ Object {
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormModificationTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 4,
       "testsuites": Array [
@@ -6934,6 +7761,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormModificationTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -6978,6 +7806,7 @@ Object {
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormPublicationTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 3,
       "testsuites": Array [
@@ -6986,6 +7815,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormPublicationTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7023,6 +7853,7 @@ Object {
       "failures": 3,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormResultsTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 7,
       "testsuites": Array [
@@ -7031,6 +7862,7 @@ Object {
           "failures": 3,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormResultsTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7104,6 +7936,7 @@ Object {
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormSearchTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 17,
       "testsuites": Array [
@@ -7112,6 +7945,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormSearchTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7247,6 +8081,7 @@ Object {
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.library.tests.FormTranslationTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 1,
       "testsuites": Array [
@@ -7255,6 +8090,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.library.tests.FormTranslationTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7278,6 +8114,7 @@ Object {
       "failures": 0,
       "hostname": "ba89c541a82f",
       "name": "org.jahia.modules.forms.permissions.tests.EditorPermissionsTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 5,
       "testsuites": Array [
@@ -7286,6 +8123,7 @@ Object {
           "failures": 0,
           "hostname": "ba89c541a82f",
           "name": "org.jahia.modules.forms.permissions.tests.EditorPermissionsTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7345,6 +8183,7 @@ Object {
       "failures": 0,
       "hostname": "ba89c541a82f",
       "name": "org.jahia.modules.forms.permissions.tests.PermissionsTabLayoutTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 1,
       "testsuites": Array [
@@ -7353,6 +8192,7 @@ Object {
           "failures": 0,
           "hostname": "ba89c541a82f",
           "name": "org.jahia.modules.forms.permissions.tests.PermissionsTabLayoutTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7378,6 +8218,7 @@ Object {
       "failures": 0,
       "hostname": "ba89c541a82f",
       "name": "org.jahia.modules.forms.permissions.tests.ResultsViewerPermissionsTest",
+      "pending": 0,
       "skipped": 0,
       "tests": 4,
       "testsuites": Array [
@@ -7386,6 +8227,7 @@ Object {
           "failures": 0,
           "hostname": "ba89c541a82f",
           "name": "org.jahia.modules.forms.permissions.tests.ResultsViewerPermissionsTest",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7438,6 +8280,7 @@ Object {
       "failures": 0,
       "hostname": "MacBook-Pro.local",
       "name": "org.jahia.modules.forms.tests.FormEnd2EndTest",
+      "pending": 0,
       "skipped": 8,
       "tests": 9,
       "testsuites": Array [
@@ -7446,6 +8289,7 @@ Object {
           "failures": 0,
           "hostname": "MacBook-Pro.local",
           "name": "org.jahia.modules.forms.tests.FormEnd2EndTest",
+          "pending": 0,
           "skipped": 8,
           "tests": Array [
             Object {
@@ -7548,10 +8392,12 @@ Object {
 exports[`Test report ingestion Mocha JUnit XML (generated using: mocha-junit-reporter) 1`] = `
 Object {
   "failures": 0,
+  "pending": 0,
   "reports": Array [
     Object {
       "failures": 0,
       "name": "Mocha Tests",
+      "pending": 0,
       "skipped": 0,
       "tests": 1,
       "testsuites": Array [
@@ -7559,6 +8405,7 @@ Object {
           "errors": NaN,
           "failures": 0,
           "name": "Test if every type in graphQL API has description",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7579,6 +8426,7 @@ Object {
     Object {
       "failures": 0,
       "name": "Mocha Tests",
+      "pending": 0,
       "skipped": 0,
       "tests": 6,
       "testsuites": Array [
@@ -7586,6 +8434,7 @@ Object {
           "errors": NaN,
           "failures": 0,
           "name": "Validate ability get current User",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7641,6 +8490,7 @@ Object {
     Object {
       "failures": 0,
       "name": "Mocha Tests",
+      "pending": 0,
       "skipped": 0,
       "tests": 8,
       "testsuites": Array [
@@ -7648,6 +8498,7 @@ Object {
           "errors": NaN,
           "failures": 0,
           "name": "Validate ability get current User",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7717,6 +8568,7 @@ Object {
     Object {
       "failures": 0,
       "name": "Mocha Tests",
+      "pending": 0,
       "skipped": 0,
       "tests": 1,
       "testsuites": Array [
@@ -7724,6 +8576,7 @@ Object {
           "errors": NaN,
           "failures": 0,
           "name": "Successfully navigates to sandbox app",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -7750,1037 +8603,31 @@ Object {
 
 exports[`Test report ingestion Multi JSON (mocha) 1`] = `
 Object {
-  "failures": 2,
-  "reports": Array [
-    Object {
-      "failures": 2,
-      "name": "Mocha JSON Report",
-      "skipped": 0,
-      "tests": 24,
-      "testsuites": Array [
-        Object {
-          "failures": 0,
-          "name": "Indexing - Validating ACLs update and indexation (acls.spec.ts.json)",
-          "skipped": 0,
-          "tests": Array [
-            Object {
-              "failures": Array [],
-              "name": "Preparing environment to run the test and removing access for guest",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response, checkGuestAcl;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().mutate({
-                        mutation: grantRoles,
-                        variables: {
-                            pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\",
-                            permission: 'GRANT',
-                            users: 'u:guest',
-                        },
-                    })];
-                case 1:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.jcr.mutateNode.addChild.addChild));
-                    expect(response.data.jcr.mutateNode.addChild.addChild.property1.setValue).to.be.true;
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: publishNode,
-                            variables: {
-                                pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl\\",
-                            },
-                        })];
-                case 2:
-                    _a.sent();
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: updateRoles,
-                            variables: {
-                                pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl/GRANT_u_guest\\",
-                                permission: 'GRANT',
-                                users: 'g:users',
-                            },
-                        })];
-                case 3:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.jcr.mutateNode));
-                    expect(response.data.jcr.mutateNode.property1.setValue).to.be.true;
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: publishNode,
-                            variables: {
-                                pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl\\",
-                            },
-                        })];
-                case 4:
-                    _a.sent();
-                    return [4 /*yield*/, apollo_1.apollo().query({
-                            query: searchResults,
-                            variables: {
-                                q: 'digitall',
-                                workspace: 'LIVE',
-                                siteKeys: [Cypress.env('AS_SITEKEY')],
-                                language: 'en',
-                                searchIn: null,
-                                pageSize: 20,
-                                pageCount: 0,
-                                sortBy: null,
-                                filters: { nodeType: { type: 'jnt:page' } },
-                            },
-                        })];
-                case 5:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.search.results.hits));
-                    expect(response.data.search.results.hits.length).to.equal(8);
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: updateRoles,
-                            variables: {
-                                pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl/GRANT_u_guest\\",
-                                permission: 'DENY',
-                                users: 'u:guest',
-                            },
-                        })];
-                case 6:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.jcr.mutateNode));
-                    expect(response.data.jcr.mutateNode.property1.setValue).to.be.true;
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: publishNode,
-                            variables: {
-                                pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl\\",
-                            },
-                        })
-                        // This function is used to check if the data has been updated and made its way to the AS index
-                        // Idea is to avoid using arbitrary sleep
-                    ];
-                case 7:
-                    _a.sent();
-                    checkGuestAcl = function (apollo, graphQLQuery) { return __awaiter(void 0, void 0, void 0, function () {
-                        var response, aboutPages;
-                        return __generator(this, function (_a) {
-                            switch (_a.label) {
-                                case 0: return [4 /*yield*/, apollo().query({
-                                        query: graphQLQuery,
-                                        variables: {
-                                            q: 'digitall',
-                                            workspace: 'LIVE',
-                                            siteKeys: [Cypress.env('AS_SITEKEY')],
-                                            language: 'en',
-                                            searchIn: null,
-                                            pageSize: 20,
-                                            pageCount: 0,
-                                            sortBy: null,
-                                            filters: { nodeType: { type: 'jnt:page' } },
-                                        },
-                                    })];
-                                case 1:
-                                    response = _a.sent();
-                                    console.log(response.data.search.results.hits.filter(function (h) {
-                                        return h.path.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\");
-                                    }));
-                                    aboutPages = response.data.search.results.hits
-                                        .filter(function (h) { return h.path.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\"); })
-                                        .filter(function (h) { return h.acl.includes('guest'); });
-                                    return [2 /*return*/, aboutPages.length === 0];
-                            }
-                        });
-                    }); };
-                    cy.log('Wait until data has been re-indexed');
-                    return [4 /*yield*/, checkDataUpdated_1.checkDataUpdated(apollo_1.apollo, searchResults, 30, checkGuestAcl)];
-                case 8:
-                    _a.sent();
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 4,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Validate that guest lost access to the /home/about/ nodes",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () {
-        cy.task('apolloNode', {
-            baseUrl: Cypress.config().baseUrl,
-            query: searchResults,
-            variables: {
-                q: 'digitall',
-                workspace: 'LIVE',
-                siteKeys: [Cypress.env('AS_SITEKEY')],
-                language: 'en',
-                searchIn: null,
-                pageSize: 20,
-                pageCount: 0,
-                sortBy: null,
-                filters: { nodeType: { type: 'jnt:page' } },
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }).then(function (response) {
-            cy.log(JSON.stringify(response));
-            var paths = response.data.search.results.hits.map(function (h) { return h.path; });
-            cy.log(JSON.stringify(paths));
-            // Check if any of the returned path contains the about node
-            expect(paths.filter(function (p) { return p.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\"); }).length).to.equal(0);
-        });
-    }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Validate that user jane still has access to the /home/about/ nodes",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () {
-        cy.task('apolloNode', {
-            baseUrl: Cypress.config().baseUrl,
-            query: searchResults,
-            authMethod: {
-                username: 'jane',
-                password: 'password',
-            },
-            variables: {
-                q: 'digitall',
-                workspace: 'LIVE',
-                siteKeys: [Cypress.env('AS_SITEKEY')],
-                language: 'en',
-                searchIn: null,
-                pageSize: 20,
-                pageCount: 0,
-                sortBy: null,
-                filters: { nodeType: { type: 'jnt:page' } },
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }).then(function (response) {
-            cy.log(JSON.stringify(response));
-            var paths = response.data.search.results.hits.map(function (h) { return h.path; });
-            cy.log(JSON.stringify(paths));
-            // Check if any of the returned path contains the about node
-            expect(paths.filter(function (p) { return p.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\"); }).length).to.be.greaterThan(0);
-        });
-    }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Restore access to guest user to the /home/about/ nodes",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response, checkGuestAcl;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().mutate({
-                        mutation: updateRoles,
-                        variables: {
-                            pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl/GRANT_u_guest\\",
-                            permission: 'GRANT',
-                            users: 'u:guest',
-                        },
-                    })];
-                case 1:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.jcr.mutateNode));
-                    expect(response.data.jcr.mutateNode.property1.setValue).to.be.true;
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: publishNode,
-                            variables: {
-                                pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl\\",
-                            },
-                        })];
-                case 2:
-                    _a.sent();
-                    checkGuestAcl = function (apollo, graphQLQuery) { return __awaiter(void 0, void 0, void 0, function () {
-                        var response, aboutPages;
-                        return __generator(this, function (_a) {
-                            switch (_a.label) {
-                                case 0: return [4 /*yield*/, apollo().query({
-                                        query: graphQLQuery,
-                                        variables: {
-                                            q: 'digitall',
-                                            workspace: 'LIVE',
-                                            siteKeys: [Cypress.env('AS_SITEKEY')],
-                                            language: 'en',
-                                            searchIn: null,
-                                            pageSize: 20,
-                                            pageCount: 0,
-                                            sortBy: null,
-                                            filters: { nodeType: { type: 'jnt:page' } },
-                                        },
-                                    })];
-                                case 1:
-                                    response = _a.sent();
-                                    console.log(response.data.search.results.hits.filter(function (h) {
-                                        return h.path.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\");
-                                    }));
-                                    aboutPages = response.data.search.results.hits
-                                        .filter(function (h) { return h.path.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\"); })
-                                        .filter(function (h) { return h.acl.includes('guest'); });
-                                    return [2 /*return*/, aboutPages.length > 0];
-                            }
-                        });
-                    }); };
-                    cy.log('Wait until data has been re-indexed');
-                    return [4 /*yield*/, checkDataUpdated_1.checkDataUpdated(apollo_1.apollo, searchResults, 30, checkGuestAcl)];
-                case 3:
-                    _a.sent();
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 2,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Validate guest user recovered access to the /home/about/ nodes",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () {
-        cy.task('apolloNode', {
-            baseUrl: Cypress.config().baseUrl,
-            query: searchResults,
-            variables: {
-                q: 'digitall',
-                workspace: 'LIVE',
-                siteKeys: [Cypress.env('AS_SITEKEY')],
-                language: 'en',
-                searchIn: null,
-                pageSize: 20,
-                pageCount: 0,
-                sortBy: null,
-                filters: { nodeType: { type: 'jnt:page' } },
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }).then(function (response) { return __awaiter(void 0, void 0, void 0, function () {
-            var paths;
-            return __generator(this, function (_a) {
-                cy.log(JSON.stringify(response));
-                paths = response.data.search.results.hits.map(function (h) { return h.path; });
-                cy.log(JSON.stringify(paths));
-                // Check if any of the returned path contains the about node
-                expect(paths.filter(function (p) { return p.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\"); }).length).to.be.greaterThan(1);
-                return [2 /*return*/];
-            });
-        }); });
-    }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Preparing environment to run the test and removing access for group g:users",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response, checkGroupsAcl;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().mutate({
-                        mutation: updateRoles,
-                        variables: {
-                            pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl/GRANT_u_guest\\",
-                            permission: 'DENY',
-                            users: 'g:users',
-                        },
-                    })];
-                case 1:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.jcr.mutateNode));
-                    expect(response.data.jcr.mutateNode.property1.setValue).to.be.true;
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: publishNode,
-                            variables: {
-                                pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl\\",
-                            },
-                        })];
-                case 2:
-                    _a.sent();
-                    checkGroupsAcl = function (apollo, graphQLQuery) { return __awaiter(void 0, void 0, void 0, function () {
-                        var response, aboutPages;
-                        return __generator(this, function (_a) {
-                            switch (_a.label) {
-                                case 0: return [4 /*yield*/, apollo().query({
-                                        query: graphQLQuery,
-                                        variables: {
-                                            q: 'digitall',
-                                            workspace: 'LIVE',
-                                            siteKeys: [Cypress.env('AS_SITEKEY')],
-                                            language: 'en',
-                                            searchIn: null,
-                                            pageSize: 20,
-                                            pageCount: 0,
-                                            sortBy: null,
-                                            filters: { nodeType: { type: 'jnt:page' } },
-                                        },
-                                    })];
-                                case 1:
-                                    response = _a.sent();
-                                    console.log(response.data.search.results.hits.filter(function (h) {
-                                        return h.path.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\");
-                                    }));
-                                    aboutPages = response.data.search.results.hits
-                                        .filter(function (h) { return h.path.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\"); })
-                                        .filter(function (h) { return h.acl.includes('groups'); });
-                                    return [2 /*return*/, aboutPages.length === 0];
-                            }
-                        });
-                    }); };
-                    cy.log('Wait until data has been re-indexed');
-                    return [4 /*yield*/, checkDataUpdated_1.checkDataUpdated(apollo_1.apollo, searchResults, 30, checkGroupsAcl)];
-                case 3:
-                    _a.sent();
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 2,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Validate that user jane (member of g:users) lost access to the /home/about/ nodes",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () {
-        cy.task('apolloNode', {
-            baseUrl: Cypress.config().baseUrl,
-            query: searchResults,
-            authMethod: {
-                username: 'jane',
-                password: 'password',
-            },
-            variables: {
-                q: 'digitall',
-                workspace: 'LIVE',
-                siteKeys: [Cypress.env('AS_SITEKEY')],
-                language: 'en',
-                searchIn: null,
-                pageSize: 20,
-                pageCount: 0,
-                sortBy: null,
-                filters: { nodeType: { type: 'jnt:page' } },
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }).then(function (response) {
-            cy.log(JSON.stringify(response));
-            var paths = response.data.search.results.hits.map(function (h) { return h.path; });
-            cy.log(JSON.stringify(paths));
-            // Check if any of the returned path contains the about node
-            expect(paths.filter(function (p) { return p.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\"); }).length).to.equal(0);
-        });
-    }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Restore access to group g:users to the /home/about/ nodes",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response, checkGuestAcl;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().mutate({
-                        mutation: updateRoles,
-                        variables: {
-                            pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl/GRANT_u_guest\\",
-                            permission: 'GRANT',
-                            users: 'g:users',
-                        },
-                    })];
-                case 1:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.jcr.mutateNode));
-                    expect(response.data.jcr.mutateNode.property1.setValue).to.be.true;
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: publishNode,
-                            variables: {
-                                pathOrId: \\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about/j:acl\\",
-                            },
-                        })];
-                case 2:
-                    _a.sent();
-                    checkGuestAcl = function (apollo, graphQLQuery) { return __awaiter(void 0, void 0, void 0, function () {
-                        var response, aboutPages;
-                        return __generator(this, function (_a) {
-                            switch (_a.label) {
-                                case 0: return [4 /*yield*/, apollo().query({
-                                        query: graphQLQuery,
-                                        variables: {
-                                            q: 'digitall',
-                                            workspace: 'LIVE',
-                                            siteKeys: [Cypress.env('AS_SITEKEY')],
-                                            language: 'en',
-                                            searchIn: null,
-                                            pageSize: 20,
-                                            pageCount: 0,
-                                            sortBy: null,
-                                            filters: { nodeType: { type: 'jnt:page' } },
-                                        },
-                                    })];
-                                case 1:
-                                    response = _a.sent();
-                                    console.log(response.data.search.results.hits.filter(function (h) {
-                                        return h.path.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\");
-                                    }));
-                                    aboutPages = response.data.search.results.hits
-                                        .filter(function (h) { return h.path.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\"); })
-                                        .filter(function (h) { return h.acl.includes('groups'); });
-                                    return [2 /*return*/, aboutPages.length > 0];
-                            }
-                        });
-                    }); };
-                    cy.log('Wait until data has been re-indexed');
-                    return [4 /*yield*/, checkDataUpdated_1.checkDataUpdated(apollo_1.apollo, searchResults, 30, checkGuestAcl)];
-                case 3:
-                    _a.sent();
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 3,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Validate that user jane (member of g:users) recovered access to the /home/about/ nodes",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () {
-        cy.task('apolloNode', {
-            baseUrl: Cypress.config().baseUrl,
-            query: searchResults,
-            authMethod: {
-                username: 'jane',
-                password: 'password',
-            },
-            variables: {
-                q: 'digitall',
-                workspace: 'LIVE',
-                siteKeys: [Cypress.env('AS_SITEKEY')],
-                language: 'en',
-                searchIn: null,
-                pageSize: 20,
-                pageCount: 0,
-                sortBy: null,
-                filters: { nodeType: { type: 'jnt:page' } },
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }).then(function (response) {
-            cy.log(JSON.stringify(response));
-            var paths = response.data.search.results.hits.map(function (h) { return h.path; });
-            cy.log(JSON.stringify(paths));
-            // Check if any of the returned path contains the about node
-            expect(paths.filter(function (p) { return p.includes(\\"/sites/\\" + Cypress.env('AS_SITEKEY') + \\"/home/about\\"); }).length).to.be.greaterThan(1);
-        });
-    }",
-              "time": 0,
-            },
-          ],
-          "time": 13,
-          "timestamp": "2021-11-01T03:33:45.039Z",
-        },
-        Object {
-          "failures": 0,
-          "name": "Test if every type in graphQL API has description (apiDescription.spec.ts.json)",
-          "skipped": 0,
-          "tests": Array [
-            Object {
-              "failures": Array [],
-              "name": "Check every input for the User Type",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () {
-        return __awaiter(this, void 0, void 0, function () {
-            var noDesc;
-            return __generator(this, function (_a) {
-                switch (_a.label) {
-                    case 0:
-                        noDesc = new Set();
-                        return [4 /*yield*/, executeTest('ASAdminQueries', noDesc)];
-                    case 1:
-                        _a.sent();
-                        console.log(noDesc);
-                        expect(JSON.stringify(Array.from(noDesc))).to.equals('[]');
-                        return [2 /*return*/];
-                }
-            });
-        });
-    }",
-              "time": 1,
-            },
-          ],
-          "time": 1,
-          "timestamp": "2021-11-01T03:29:15.788Z",
-        },
-        Object {
-          "failures": 0,
-          "name": "Filters - Filtering by author (author.spec.ts.json)",
-          "skipped": 0,
-          "tests": Array [
-            Object {
-              "failures": Array [],
-              "name": "Filter by author - root",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response, hits, _i, hits_1, h;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().query({
-                        query: searchResults,
-                        variables: {
-                            q: 'demo',
-                            siteKeys: [Cypress.env('AS_SITEKEY1')],
-                            workspace: 'LIVE',
-                            searchIn: ['CONTENT'],
-                            language: 'en',
-                            filters: {
-                                author: 'root',
-                            },
-                        },
-                    })];
-                case 1:
-                    response = _a.sent();
-                    hits = response.data.search.results.hits;
-                    cy.log(JSON.stringify(hits.map(function (h) {
-                        return { displayableName: h.displayableName, createdBy: h.createdBy };
-                    })));
-                    for (_i = 0, hits_1 = hits; _i < hits_1.length; _i++) {
-                        h = hits_1[_i];
-                        expect(h.path).to.contain(\\"/sites/\\" + Cypress.env('AS_SITEKEY1') + \\"/\\");
-                        expect(['root', 'system']).to.include(h.createdBy);
-                    }
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Filter by author - root - (DEPRECATED jcr node)",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response, hits, _i, hits_2, h;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().query({
-                        query: deprecatedSearchResults,
-                        variables: {
-                            q: 'demo',
-                            siteKey: Cypress.env('AS_SITEKEY1'),
-                            workspace: 'LIVE',
-                            searchIn: ['CONTENT'],
-                            language: 'en',
-                            filter: {
-                                author: 'root',
-                            },
-                        },
-                    })];
-                case 1:
-                    response = _a.sent();
-                    hits = response.data.jcr.searches.search.hits;
-                    cy.log(JSON.stringify(hits.map(function (h) {
-                        return { displayableName: h.displayableName, createdBy: h.createdBy };
-                    })));
-                    for (_i = 0, hits_2 = hits; _i < hits_2.length; _i++) {
-                        h = hits_2[_i];
-                        expect(h.path).to.contain(\\"/sites/\\" + Cypress.env('AS_SITEKEY1') + \\"/\\");
-                        expect(['root', 'system']).to.include(h.createdBy);
-                    }
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Filter by author - system",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response, hits, _i, hits_3, h;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().query({
-                        query: searchResults,
-                        variables: {
-                            q: 'demo',
-                            siteKeys: [Cypress.env('AS_SITEKEY1')],
-                            workspace: 'LIVE',
-                            searchIn: ['CONTENT'],
-                            language: 'en',
-                            filters: {
-                                author: 'system',
-                            },
-                        },
-                    })];
-                case 1:
-                    response = _a.sent();
-                    hits = response.data.search.results.hits;
-                    cy.log(JSON.stringify(hits.map(function (h) {
-                        return { displayableName: h.displayableName, createdBy: h.createdBy };
-                    })));
-                    for (_i = 0, hits_3 = hits; _i < hits_3.length; _i++) {
-                        h = hits_3[_i];
-                        expect(h.path).to.contain(\\"/sites/\\" + Cypress.env('AS_SITEKEY1') + \\"/\\");
-                        expect(['system']).to.include(h.createdBy);
-                    }
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Filter by author - system - (DEPRECATED jcr node)",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response, hits, _i, hits_4, h;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().query({
-                        query: deprecatedSearchResults,
-                        variables: {
-                            q: 'demo',
-                            siteKey: Cypress.env('AS_SITEKEY1'),
-                            workspace: 'LIVE',
-                            searchIn: ['CONTENT'],
-                            language: 'en',
-                            filter: {
-                                author: 'system',
-                            },
-                        },
-                    })];
-                case 1:
-                    response = _a.sent();
-                    hits = response.data.jcr.searches.search.hits;
-                    cy.log(JSON.stringify(hits.map(function (h) {
-                        return { displayableName: h.displayableName, createdBy: h.createdBy };
-                    })));
-                    for (_i = 0, hits_4 = hits; _i < hits_4.length; _i++) {
-                        h = hits_4[_i];
-                        expect(h.path).to.contain(\\"/sites/\\" + Cypress.env('AS_SITEKEY1') + \\"/\\");
-                        expect(['system']).to.include(h.createdBy);
-                    }
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-          ],
-          "time": 1,
-          "timestamp": "2021-11-01T03:30:57.894Z",
-        },
-        Object {
-          "failures": 2,
-          "name": "Admin - UI operations on Augmented Search DB connection (connectionTest.spec.ts.json)",
-          "skipped": 0,
-          "tests": Array [
-            Object {
-              "failures": Array [
-                Object {
-                  "text": "{\\"message\\":\\"The following error originated from your application code, not from Cypress.\\\\n\\\\n  > Cannot read property 'size' of undefined\\\\n\\\\nWhen Cypress detects uncaught errors originating from your application it will automatically fail the current test.\\\\n\\\\nThis behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.\\\\n\\\\nhttps://on.cypress.io/uncaught-exception-from-application\\",\\"name\\":\\"TypeError\\",\\"stack\\":\\"TypeError: The following error originated from your application code, not from Cypress.\\\\n\\\\n  > Cannot read property 'size' of undefined\\\\n\\\\nWhen Cypress detects uncaught errors originating from your application it will automatically fail the current test.\\\\n\\\\nThis behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.\\\\n\\\\nhttps://on.cypress.io/uncaught-exception-from-application\\\\n    at Jp (http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js:1:292726)\\\\n    at Module.Xu (http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js:1:335005)\\\\n    at http://jahia:8080/modules/site-settings-publication/javascript/apps/sitesettingspublication.js:5:34\\",\\"sourceMappedStack\\":\\"TypeError: The following error originated from your application code, not from Cypress.\\\\n\\\\n    > Cannot read property 'size' of undefined\\\\n\\\\nWhen Cypress detects uncaught errors originating from your application it will automatically fail the current test.\\\\n\\\\nThis behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.\\\\n    at Jp (http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js:1:292727)\\\\n    at Module.Xu (http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js:1:335006)\\\\n    at <unknown> (http://jahia:8080/modules/site-settings-publication/javascript/apps/sitesettingspublication.js:5:35)\\",\\"parsedStack\\":[{\\"message\\":\\"TypeError: The following error originated from your application code, not from Cypress.\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"  > Cannot read property 'size' of undefined\\",\\"whitespace\\":\\"  \\"},{\\"message\\":\\"\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"When Cypress detects uncaught errors originating from your application it will automatically fail the current test.\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"This behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.\\",\\"whitespace\\":\\"\\"},{\\"function\\":\\"Jp\\",\\"fileUrl\\":\\"http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js\\",\\"originalFile\\":\\"http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js\\",\\"line\\":1,\\"column\\":292727,\\"whitespace\\":\\"    \\"},{\\"function\\":\\"Module.Xu\\",\\"fileUrl\\":\\"http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js\\",\\"originalFile\\":\\"http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js\\",\\"line\\":1,\\"column\\":335006,\\"whitespace\\":\\"    \\"},{\\"function\\":\\"<unknown>\\",\\"fileUrl\\":\\"http://jahia:8080/modules/site-settings-publication/javascript/apps/sitesettingspublication.js\\",\\"originalFile\\":\\"http://jahia:8080/modules/site-settings-publication/javascript/apps/sitesettingspublication.js\\",\\"line\\":5,\\"column\\":35,\\"whitespace\\":\\"    \\"}]}",
-                },
-              ],
-              "name": "Access the page and validate \\"ADD CONNECTION\\" button (no connection present)",
-              "skipped": 0,
-              "status": "FAIL",
-              "steps": "function () {
-        as_admin_page_1.asAdminPage.goTo();
-        expect(as_admin_page_1.asAdminPage.getByText('button', 'ADD CONNECTION')).not.to.be.undefined;
-    }",
-              "time": 6,
-            },
-            Object {
-              "failures": Array [
-                Object {
-                  "text": "{\\"message\\":\\"The following error originated from your application code, not from Cypress.\\\\n\\\\n  > Cannot read property 'size' of undefined\\\\n\\\\nWhen Cypress detects uncaught errors originating from your application it will automatically fail the current test.\\\\n\\\\nThis behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.\\\\n\\\\nhttps://on.cypress.io/uncaught-exception-from-application\\",\\"name\\":\\"TypeError\\",\\"stack\\":\\"TypeError: The following error originated from your application code, not from Cypress.\\\\n\\\\n  > Cannot read property 'size' of undefined\\\\n\\\\nWhen Cypress detects uncaught errors originating from your application it will automatically fail the current test.\\\\n\\\\nThis behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.\\\\n\\\\nhttps://on.cypress.io/uncaught-exception-from-application\\\\n    at Jp (http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js:1:292726)\\\\n    at Module.Xu (http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js:1:335005)\\\\n    at http://jahia:8080/modules/site-settings-publication/javascript/apps/sitesettingspublication.js:5:34\\",\\"sourceMappedStack\\":\\"TypeError: The following error originated from your application code, not from Cypress.\\\\n\\\\n    > Cannot read property 'size' of undefined\\\\n\\\\nWhen Cypress detects uncaught errors originating from your application it will automatically fail the current test.\\\\n\\\\nThis behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.\\\\n    at Jp (http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js:1:292727)\\\\n    at Module.Xu (http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js:1:335006)\\\\n    at <unknown> (http://jahia:8080/modules/site-settings-publication/javascript/apps/sitesettingspublication.js:5:35)\\",\\"parsedStack\\":[{\\"message\\":\\"TypeError: The following error originated from your application code, not from Cypress.\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"  > Cannot read property 'size' of undefined\\",\\"whitespace\\":\\"  \\"},{\\"message\\":\\"\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"When Cypress detects uncaught errors originating from your application it will automatically fail the current test.\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"\\",\\"whitespace\\":\\"\\"},{\\"message\\":\\"This behavior is configurable, and you can choose to turn this off by listening to the \`uncaught:exception\` event.\\",\\"whitespace\\":\\"\\"},{\\"function\\":\\"Jp\\",\\"fileUrl\\":\\"http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js\\",\\"originalFile\\":\\"http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js\\",\\"line\\":1,\\"column\\":292727,\\"whitespace\\":\\"    \\"},{\\"function\\":\\"Module.Xu\\",\\"fileUrl\\":\\"http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js\\",\\"originalFile\\":\\"http://jahia:8080/modules/jcontent/javascript/apps/5454.jcontent.06213e.js\\",\\"line\\":1,\\"column\\":335006,\\"whitespace\\":\\"    \\"},{\\"function\\":\\"<unknown>\\",\\"fileUrl\\":\\"http://jahia:8080/modules/site-settings-publication/javascript/apps/sitesettingspublication.js\\",\\"originalFile\\":\\"http://jahia:8080/modules/site-settings-publication/javascript/apps/sitesettingspublication.js\\",\\"line\\":5,\\"column\\":35,\\"whitespace\\":\\"    \\"}]}",
-                },
-              ],
-              "name": "Access the page and slect the connection and cancel",
-              "skipped": 0,
-              "status": "FAIL",
-              "steps": "function () {
-        as_admin_page_1.asAdminPage.goTo();
-        as_admin_page_1.asAdminPage.clickAddConnection();
-    }",
-              "time": 1,
-            },
-          ],
-          "time": 8,
-          "timestamp": "2021-11-01T03:29:45.215Z",
-        },
-        Object {
-          "failures": 0,
-          "name": "Admin - API operations with dbConnections (dbConnections.spec.ts.json)",
-          "skipped": 0,
-          "tests": Array [
-            Object {
-              "failures": Array [],
-              "name": "Verifies current connection is empty",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().query({
-                        query: getDbConnections,
-                    })];
-                case 1:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.admin.search.currentConnection));
-                    expect(response.data.admin.search.currentConnection).to.be.equal(null);
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "List available dbConnections",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().query({
-                        query: getDbConnections,
-                    })];
-                case 1:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.admin.search.dbConnections));
-                    expect(response.data.admin.search.dbConnections.length).to.be.greaterThan(0);
-                    expect(response.data.admin.search.dbConnections[0].connectionId).to.equal(Cypress.env('AS_DBCONNECTION'));
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "List available dbConnections - Check plugins",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response, asConnection;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().query({
-                        query: getDbConnections,
-                    })];
-                case 1:
-                    response = _a.sent();
-                    asConnection = response.data.admin.search.dbConnections.find(function (c) { return c.connectionId === Cypress.env('AS_DBCONNECTION'); });
-                    cy.log(JSON.stringify(asConnection));
-                    expect(asConnection).not.to.equal(undefined);
-                    expect(asConnection.plugins.length).to.be.greaterThan(0);
-                    expect(asConnection.plugins[0].name).not.to.equal(undefined);
-                    expect(asConnection.plugins[0].description).not.to.equal(undefined);
-                    expect(asConnection.plugins[0].version).not.to.equal(undefined);
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Cannot set empty dbConnectionId",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var err_1;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    _a.trys.push([0, 2, , 3]);
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: setDbConnection,
-                            variables: {
-                                connectionId: '',
-                            },
-                        })];
-                case 1:
-                    _a.sent();
-                    return [3 /*break*/, 3];
-                case 2:
-                    err_1 = _a.sent();
-                    console.log(err_1);
-                    cy.log(JSON.stringify(err_1));
-                    expect(err_1.graphQLErrors[0].message).to.contain('No such connection exist');
-                    return [3 /*break*/, 3];
-                case 3: return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Cannot set non-existing dbConnectionId",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var err_2;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    _a.trys.push([0, 2, , 3]);
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: setDbConnection,
-                            variables: {
-                                connectionId: 'I-do-not-exist',
-                            },
-                        })];
-                case 1:
-                    _a.sent();
-                    return [3 /*break*/, 3];
-                case 2:
-                    err_2 = _a.sent();
-                    console.log(err_2);
-                    cy.log(JSON.stringify(err_2));
-                    expect(err_2.graphQLErrors[0].message).to.contain('No such connection exist');
-                    return [3 /*break*/, 3];
-                case 3: return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Set valid dbConnection",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, apollo_1.apollo().mutate({
-                        mutation: setDbConnection,
-                        variables: {
-                            connectionId: Cypress.env('AS_DBCONNECTION'),
-                        },
-                    })];
-                case 1:
-                    _a.sent();
-                    return [4 /*yield*/, apollo_1.apollo().query({
-                            query: getDbConnections,
-                        })];
-                case 2:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response.data.admin.search.dbConnections));
-                    expect(response.data.admin.search.currentConnection).to.be.equal(Cypress.env('AS_DBCONNECTION'));
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Cannot clear dbConnection if site configured",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var err_3;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: 
-                // Add a site to validate that the connection cannot be removed
-                return [4 /*yield*/, apollo_1.apollo().mutate({
-                        mutation: addSite,
-                        variables: {
-                            siteKey: Cypress.env('AS_SITEKEY'),
-                        },
-                    })];
-                case 1:
-                    // Add a site to validate that the connection cannot be removed
-                    _a.sent();
-                    _a.label = 2;
-                case 2:
-                    _a.trys.push([2, 4, , 5]);
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: clearDbConnection,
-                        })];
-                case 3:
-                    _a.sent();
-                    return [3 /*break*/, 5];
-                case 4:
-                    err_3 = _a.sent();
-                    expect(err_3.graphQLErrors[0].message).to.contain('Please remove all site from Augmented Search before clearing connection');
-                    return [3 /*break*/, 5];
-                case 5: return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-            Object {
-              "failures": Array [],
-              "name": "Can clear dbConnection if no site configured",
-              "skipped": 0,
-              "status": "PASS",
-              "steps": "function () { return __awaiter(void 0, void 0, void 0, function () {
-        var response;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: 
-                // Remove site so that the connection can be removed
-                return [4 /*yield*/, apollo_1.apollo().mutate({
-                        mutation: removeSite,
-                        variables: {
-                            siteKey: Cypress.env('AS_SITEKEY'),
-                        },
-                    })];
-                case 1:
-                    // Remove site so that the connection can be removed
-                    _a.sent();
-                    return [4 /*yield*/, apollo_1.apollo().mutate({
-                            mutation: clearDbConnection,
-                        })];
-                case 2:
-                    response = _a.sent();
-                    cy.log(JSON.stringify(response));
-                    expect(response.data.admin.search.clearDbConnection).to.equal('Successful');
-                    return [2 /*return*/];
-            }
-        });
-    }); }",
-              "time": 0,
-            },
-          ],
-          "time": 2,
-          "timestamp": "2021-11-01T03:29:29.827Z",
-        },
-      ],
-      "time": 25,
-    },
-  ],
+  "failures": 0,
+  "pending": 0,
+  "reports": Array [],
   "skipped": 0,
-  "tests": 24,
-  "time": 25,
+  "tests": 0,
+  "time": 0,
 }
 `;
 
 exports[`Test report ingestion Single JSON (mochawesome-merge) - With failure 1`] = `
 Object {
   "failures": 0,
+  "pending": 0,
   "reports": Array [
     Object {
       "failures": 0,
       "name": "report.json",
+      "pending": 0,
+      "skipped": 0,
       "tests": 31,
       "testsuites": Array [
         Object {
           "failures": 0,
           "name": "admin.configuration",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -8979,6 +8826,7 @@ readConfig({
         Object {
           "failures": 0,
           "name": "admin.datetime - Jahia Server time",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9015,6 +8863,7 @@ readConfig({
         Object {
           "failures": 0,
           "name": "Test admin user endpoint",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9170,6 +9019,7 @@ readConfig({
         Object {
           "failures": 0,
           "name": "Test admin users endpont",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9285,6 +9135,7 @@ readConfig({
         Object {
           "failures": 0,
           "name": "Test if every type in graphQL API has description",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9339,6 +9190,7 @@ cy.apolloClient().then(function (client) { return executeTest(client, 'Query', t
         Object {
           "failures": 0,
           "name": "Validate ability get current User",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9407,6 +9259,7 @@ cy.apolloClient().then(function (client) { return executeTest(client, 'Query', t
         Object {
           "failures": 0,
           "name": "Test page properties",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9436,7 +9289,7 @@ cy.apolloClient().then(function (client) { return executeTest(client, 'Query', t
       "timestamp": "2021-10-29T17:28:00.882Z",
     },
   ],
-  "skipped": NaN,
+  "skipped": 0,
   "tests": 31,
   "time": 14,
 }
@@ -9445,15 +9298,19 @@ cy.apolloClient().then(function (client) { return executeTest(client, 'Query', t
 exports[`Test report ingestion Single JSON (mochawesome-merge) - Without failure 1`] = `
 Object {
   "failures": 1,
+  "pending": 0,
   "reports": Array [
     Object {
       "failures": 1,
       "name": "report.json",
+      "pending": 0,
+      "skipped": 0,
       "tests": 16,
       "testsuites": Array [
         Object {
           "failures": 0,
           "name": "Validate password change",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9535,6 +9392,7 @@ settings_connection_jcustomer_page_1.settingsConnectionJcustomer.goTo().verifyJc
         Object {
           "failures": 0,
           "name": "DEMO - Validate ability get current User",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9632,6 +9490,7 @@ cy.apolloQuery((0, apollo_1.apollo)(Cypress.config().baseUrl, {}), {
         Object {
           "failures": 0,
           "name": "Validate jExperience Healthcheck module",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9702,6 +9561,7 @@ cy.apolloQuery((0, apollo_1.apollo)(Cypress.config().baseUrl, {}), {
         Object {
           "failures": 0,
           "name": "jexperience",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9722,6 +9582,7 @@ cy.apolloQuery((0, apollo_1.apollo)(Cypress.config().baseUrl, {}), {
         Object {
           "failures": 0,
           "name": "basic personalization test",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9755,6 +9616,7 @@ testSite_test_page_1.testSitePage.goTo(testPagePath).verifySimpleTextNotDisplaye
         Object {
           "failures": 1,
           "name": "profile export in csv",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9851,6 +9713,7 @@ cy.task('listFiles', { downloadFolder: downloadFolder }).then(function (list) {
         Object {
           "failures": 0,
           "name": "profile import from csv",
+          "pending": 0,
           "skipped": 0,
           "tests": Array [
             Object {
@@ -9932,7 +9795,7 @@ cy.request(profileListHelpers_1.requestProfileList).then(function (resp) {
       "timestamp": "2021-10-29T13:18:13.161Z",
     },
   ],
-  "skipped": NaN,
+  "skipped": 0,
   "tests": 16,
   "time": 93,
 }


### PR DESCRIPTION
The JSON parser was used at the very beginning of jahia-reporter, we then moved to JUnit XML.

The JUnit XML format, although compatible with our Selenium tests is lacking reporting elements present in Cypress tests (pending and skipped states).

The goal of this PR is to remove the legacy JSON parser (not used anymore) and update the mocha parser to include skipped and pending states.

From there we'd be able to use the JSON parser for most cases without breaking existing XML tests. The only caveat is that we'll need to ensure we have mocha reports available for all Cypress tests