### PR TITLE
Fix handling of the project name

### DIFF
--- a/src/commands/zencrepes.ts
+++ b/src/commands/zencrepes.ts
@@ -88,7 +88,7 @@ class JahiaTestrailReporter extends Command {
 
     // If dependencies were previously fetched, use those for the module
     let dependencies = JSON.parse(flags.dependencies)
-    let name = flags.name
+    let name = ''
     let version = flags.version
     let jahiaFullVersion = ''
     let moduleVersion = ''
@@ -109,6 +109,10 @@ class JahiaTestrailReporter extends Command {
       dependencies = [...dependencies, ...versions.dependencies]
       version = versions.module.version
       name = versions.module.id
+    }
+    // If name could not be fetched from the module file, fallback on the flag value
+    if (name === '') {
+      name = flags.name
     }
 
     // Get all individual test cases in an array

--- a/src/commands/zencrepes.ts
+++ b/src/commands/zencrepes.ts
@@ -90,13 +90,13 @@ class JahiaTestrailReporter extends Command {
     let dependencies = JSON.parse(flags.dependencies)
     let name = ''
     let version = flags.version
-    let jahiaFullVersion = ''
+    let jahiaVersion = ''
     let moduleVersion = ''
     if (flags.moduleFilepath !== undefined) {
       const versionFile: any = fs.readFileSync(flags.moduleFilepath)
       const versions: UtilsVersions = JSON.parse(versionFile)
-      if (versions.jahia.fullVersion !== '') {
-        jahiaFullVersion = versions.jahia.fullVersion
+      if (versions.jahia.version !== '') {
+        jahiaVersion = `Jahia ${versions.jahia.version}` 
       }
       if (versions.module.id !== '' && versions.module.version !== '') {
         moduleVersion = `${versions.module.id}-${versions.module.version}`
@@ -126,7 +126,7 @@ class JahiaTestrailReporter extends Command {
             suite: suite.name,
             duration: test.time,
             state: test.status,
-            jahia: jahiaFullVersion,
+            jahia: jahiaVersion,
             module: moduleVersion,
             caseTotal: 1, // Hack to fit in Zencrepes ZUI existing data model
             caseSuccess: test.status === 'PASS' ? 1 : 0,


### PR DESCRIPTION
The current situation is causing an issue when we're not testing a particular module (for example when testing on jahia-ee,n jahia-private, ...).

If the module cannot be fetched from the list of installed modules, then it's falling back on the name provided to the tool.