### PR TITLE
fix: updated testrail API to react to since they introduced pagination in ARCH-284

### DIFF
--- a/src/utils/testrail.interface.ts
+++ b/src/utils/testrail.interface.ts
@@ -61,6 +61,13 @@ export interface ResultFieldConfig {
   };
 }
 
+export interface PaginatedSuites {
+  offset: number;
+  limit: number;
+  size: number;
+  suites: Suite[];
+}
+
 export interface Suite {
   id: number;
   name: string;

--- a/src/utils/testrail.ts
+++ b/src/utils/testrail.ts
@@ -1,5 +1,5 @@
 import {SyncRequestClient} from 'ts-sync-request/dist'
-import {AddCase, PaginatedProjects, Project, PaginatedSections, ResultField, Section, Suite, PaginatedTests, Test, TestRailResult, AddRun, Run, CaseFields, PaginatedMilestones, Milestone} from './testrail.interface'
+import {AddCase, PaginatedProjects, Project, PaginatedSections, ResultField, Section, PaginatedSuites, Suite, PaginatedTests, Test, TestRailResult, AddRun, Run, CaseFields, PaginatedMilestones, Milestone} from './testrail.interface'
 
 export class TestRailClient {
     public base: string
@@ -31,7 +31,8 @@ export class TestRailClient {
     }
 
     public getSuites(projectId: number): Suite[] {
-      return this.sendRequest('GET', 'get_suites/' + projectId.toString(), '') as Suite[]
+      const getSuites = this.sendRequest('GET', 'get_suites/' + projectId.toString(), '') as PaginatedSuites
+      return getSuites.suites as Suite[]
     }
 
     public getMilestones(projectId: number): Milestone[] {


### PR DESCRIPTION
This was causing the following error:

```
  Get all suites for project 1
      TypeError: testrail.getSuites(...).find is not a function
  There was an issue processing the command (Error). It failed at: "2025-07-17T02:53:59.487Z"
Error: ENOENT: no such file or directory, stat '/opt/actions-runner/_work/jexperience/jexperience/tests/artifacts/results/testrail_link'
```

This appears to be related to a change in Testrail API: https://support.testrail.com/hc/en-us/articles/39188927555092-TestRail-9-3-1-Default-1020 (see ARCH-284)
