### PR TITLE
feat: use 'tags' from test results to update labels field in TestRail

### DIFF
--- a/src/commands/testrail.ts
+++ b/src/commands/testrail.ts
@@ -34,6 +34,7 @@ import {
   getTestrailSections,
   getTestrailSuite,
   parseTestsFromReports,
+  updateTestCase,
 } from '../utils/testrail/index.js';
 
 export default class TestrailCommand extends Command {
@@ -133,18 +134,13 @@ static override flags = {
     if (flags.runName === 'AE - ') {
       const date = new Date();
       const format = 'YYYY-MM-DD HH:mm:ss [GMT]Z (z)';
-      const runDate = formatToTimeZone(date, format, {
-        timeZone: 'Europe/Paris',
-      });
+      const runDate = formatToTimeZone(date, format, {timeZone: 'Europe/Paris'});
       const profile = flags.profile.trim();
       const runSource =
-        profile !== ''
-          ? profile
-          : flags.parentSection === ''
-            ? flags.projectName
-            : flags.parentSection;
-      flags.runName +=
-        `${runSource}-${runDate}`;
+        profile === '' ?
+          (flags.parentSection === '' ? flags.projectName : flags.parentSection) :
+          profile;
+      flags.runName += `${runSource}-${runDate}`;
     }
 
     this.log(`Will be creating a Testrail run with name: ${flags.runName}`);
@@ -324,6 +320,7 @@ static override flags = {
     // Make sure all test cases exist in TestRail
     // First get all test cases from TestRail, by section
     const testCasesInTestrail: Record<string, Test[]> = {};
+    const testCasesToUpdate: Array<{ caseId: number; tags: string[] }> = [];
     for (const executedSection of executedSections) {
       if (!flags.skip) {
         ux.action.start(
@@ -343,6 +340,16 @@ static override flags = {
 
     // Go over the executed tests and make sure they all exist in the list we just got from TestRail
     for (const test of tests) {
+      // Collect all unique non-empty tags from the test-case results
+      const testCaseTags = new Set((test.meta?.tags ?? [])
+          .map((tag: string) => tag.trim())
+          .filter((str: string) => str !== ''),
+      );
+
+      // debug info, to be removed
+      // this.log('CONTEXT: ' + JSON.stringify(test.meta));
+      // this.log('TAGS: ' + [...testCaseTags].join(', '));
+
       if (flags.skip) {
         this.log(`Get test data ${JSON.stringify(test)}`);
       } else {
@@ -350,6 +357,7 @@ static override flags = {
         const foundTestCaseInTestRail = testCasesInTestrail[test.section].find(
           (t) => t.title === test.title,
         );
+
         // if it's not found we are creating it
         if (foundTestCaseInTestRail === undefined) {
           ux.action.start(
@@ -362,16 +370,20 @@ static override flags = {
             'Complete',
           );
 
-          // Search for the ID corrsponding to the provided Jahia version
+          // Search for the ID corresponding to the provided Jahia version
           const customVersion = await getTestrailCustomVersion(
             testrailCaseFields,
             '8.0.1.0',
           );
+
+          // Compose new TEST-CASE data
           const newTestCase: AddCase = {
             custom_status: customStatus,
             custom_version: customVersion,
+            labels: [...testCaseTags] as string[],
             title: test.title,
           };
+
           // Only Cypress reports at the moment are expected to have the steps field
           if (test.steps !== undefined) {
             newTestCase.custom_steps_separated = [
@@ -391,6 +403,7 @@ static override flags = {
               `Something unexpected happened. Section ${test.section} was not found and not created.`,
             );
           } else {
+            // Add new TEST-CASE to TestRail
             const createdCase = await addTestrailCase(
               testrailConfig,
               section.id,
@@ -402,6 +415,29 @@ static override flags = {
         } else {
           // the test exists in TestRail, so we'll just keep the ID
           test.id = foundTestCaseInTestRail.id;
+
+          // Compare LABELS from the TestRail and TAGS from test results
+          // If expected and existing ones are equal (doesn't matter - emtpy or not) then skip updating.
+          // Otherwise, update TESTRAIL LABELS with expected TAGS, overriding all existing ones.
+
+          // Filter non-empty unique "existing" labels from the TestRail results
+          const testRailLabels = new Set((foundTestCaseInTestRail.labels ?? [])
+              .map((label) => label.title.trim())
+              .filter((title) => title !== '')
+          );
+
+          // Compare TestRail labels with test-case result's tags
+          const labelsAreEqual =
+            testRailLabels.size === testCaseTags.size &&
+            [...testCaseTags].every((tag) => testRailLabels.has(tag as string));
+
+          // If there is any difference - store new ("expected") labels in the queue for further update
+          if (!labelsAreEqual) {
+            testCasesToUpdate.push({
+              caseId: test.id as number,
+              tags: [...testCaseTags] as string[]
+            });
+          }
         }
       }
     }
@@ -439,7 +475,7 @@ static override flags = {
     for (const test of tests) {
       if (test.id === undefined) {
         this.error(
-          `Something unexpected happened. Test ${test.title} does not have an ID.`,
+          `Something unexpected happened. Test [${test.title}] does not have an ID.`,
         );
       } else {
         // If there's a comment argument on the object it means the test failed.
@@ -482,8 +518,19 @@ static override flags = {
     this.log(`Updating test run in batch for ${results.length} results`);
     if (flags.skip) {
       this.log(`Results: ${JSON.stringify(results)}`);
+      this.log(`Will update labels for ${testCasesToUpdate.length} existing case(s) if any`);
     } else {
+      // Add TEST-CASE execution's result
       await addTestrailResults(testrailConfig, run.id, results);
+
+      // Update TEST-CASE labels in TestRail (if any)
+      if (testCasesToUpdate.length > 0) {
+        this.log(`Updating labels for ${testCasesToUpdate.length} existing case(s)`);
+        for (const testcase of testCasesToUpdate) {
+          await updateTestCase(testrailConfig, testcase.caseId, {labels: testcase.tags});
+          this.log(`Updated labels for case ${testcase.caseId}: [${testcase.tags.join(', ')}]`);
+        }
+      }
     }
 
     this.log('Closing test run');

--- a/src/commands/testrail.ts
+++ b/src/commands/testrail.ts
@@ -347,7 +347,7 @@ static override flags = {
       );
 
       // debug info, to be removed
-      // this.log('CONTEXT: ' + JSON.stringify(test.meta));
+      // this.log('META: ' + JSON.stringify(test.meta));
       // this.log('TAGS: ' + [...testCaseTags].join(', '));
 
       if (flags.skip) {

--- a/src/types/report.types.ts
+++ b/src/types/report.types.ts
@@ -4,6 +4,7 @@ export interface JRTestfailure {
 
 export interface JRTestcase {
   failures: JRTestfailure[];
+  meta?: string | undefined;
   name: string;
   status: string;
   steps?: string;

--- a/src/types/testrail.types.ts
+++ b/src/types/testrail.types.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 export interface TestRailConfig {
   base: string;
   enableRateLimiting?: boolean;
@@ -20,7 +22,6 @@ export enum Status {
 }
 
 export interface TestRailResult {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any; // Allow custom fields
   case_id: number;
   comment?: string;
@@ -126,9 +127,23 @@ export interface PaginatedTests {
   size: number;
 }
 
+export interface TestRailLabel {
+  created_by: number;
+  created_on: number;
+  id: number;
+  title: string;
+}
+
+/**
+ * Interface is used in both cases - for test-case from cypress report and from TestRail.
+ * Thus use both - 'meta' (containing meta-info from cypress report, along with labels
+ * and 'labels' attributes (both optional to handle both cases).
+ */
 export interface Test {
   comment?: string;
   id?: number;
+  labels?: Array<TestRailLabel>;
+  meta?: any;
   section: string;
   section_id?: string;
   steps?: string;
@@ -142,10 +157,22 @@ export interface TestWithStatus extends Test {
 
 export interface AddCase {
   custom_status: number;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   custom_steps_separated?: any[];
   custom_version: number[];
+  labels?: string[];
   title: string;
+}
+
+// Same with <Test> but all fields are optional
+export interface UpdateCase {
+  comment?: string;
+  id?: number;
+  labels?: string[];
+  section?: string;
+  section_id?: string;
+  steps?: string;
+  time?: string;
+  title?: string;
 }
 
 export interface Run {

--- a/src/utils/ingest/parseJsonReport.ts
+++ b/src/utils/ingest/parseJsonReport.ts
@@ -114,9 +114,12 @@ const mochaParser = (rawReports: any[]): JRRun => {
               // "configs":[{"context":{"is_global":true,"project_ids":[24,20,29,7,6,4 ...] ...
               // thus use separate attribute "meta: test.context", for manipulations with
               // test result's context and to avoid confusion with those.
-              // Add meta ONLY if data exists to avoid breaking other cases.
+              // Keep context only when it is a plain object; ignore malformed formats.
               const metaInfo =
-                test.context !== undefined && test.context !== null
+                test.context !== undefined &&
+                test.context !== null &&
+                typeof test.context === 'object' &&
+                !Array.isArray(test.context)
                   ? { meta: test.context }
                   : {};
 

--- a/src/utils/ingest/parseJsonReport.ts
+++ b/src/utils/ingest/parseJsonReport.ts
@@ -114,12 +114,8 @@ const mochaParser = (rawReports: any[]): JRRun => {
               // "configs":[{"context":{"is_global":true,"project_ids":[24,20,29,7,6,4 ...] ...
               // thus use separate attribute "meta: test.context", for manipulations with
               // test result's context and to avoid confusion with those.
-              // Keep context only when it is a plain object; ignore malformed formats.
               const metaInfo =
-                test.context !== undefined &&
-                test.context !== null &&
-                typeof test.context === 'object' &&
-                !Array.isArray(test.context)
+                test.context !== undefined && test.context !== null
                   ? { meta: test.context }
                   : {};
 

--- a/src/utils/ingest/parseJsonReport.ts
+++ b/src/utils/ingest/parseJsonReport.ts
@@ -110,8 +110,13 @@ const mochaParser = (rawReports: any[]): JRRun => {
                 status = 'PENDING';
               }
 
+              // Some TestRail responses contain "context" attribute, containing TestRail specific data, e.g.:
+              // "configs":[{"context":{"is_global":true,"project_ids":[24,20,29,7,6,4 ...] ...
+              // thus use separate attribute "meta: test.context", for manipulations with
+              // test result's context and to avoid confusion with those
               return {
                 failures: [{ text: test.err.estack }],
+                meta: test.context,
                 name: test.title,
                 status,
                 steps: test.code,

--- a/src/utils/ingest/parseJsonReport.ts
+++ b/src/utils/ingest/parseJsonReport.ts
@@ -113,10 +113,16 @@ const mochaParser = (rawReports: any[]): JRRun => {
               // Some TestRail responses contain "context" attribute, containing TestRail specific data, e.g.:
               // "configs":[{"context":{"is_global":true,"project_ids":[24,20,29,7,6,4 ...] ...
               // thus use separate attribute "meta: test.context", for manipulations with
-              // test result's context and to avoid confusion with those
+              // test result's context and to avoid confusion with those.
+              // Add meta ONLY if data exists to avoid breaking other cases.
+              const metaInfo =
+                test.context !== undefined && test.context !== null
+                  ? { meta: test.context }
+                  : {};
+
               return {
                 failures: [{ text: test.err.estack }],
-                meta: test.context,
+                ...metaInfo,
                 name: test.title,
                 status,
                 steps: test.code,

--- a/src/utils/testrail/parser.ts
+++ b/src/utils/testrail/parser.ts
@@ -1,6 +1,28 @@
 import type { JRRun, TestWithStatus } from '../../types/index.js';
 
 /**
+ * Meta-data entry type
+ */
+type MetaEntry = {
+  title: string;
+  value: unknown;
+};
+
+/**
+ * Ensures the entry has a proper type
+ * @param entry meta-data entry
+ */
+function isMetaEntry(entry: unknown): entry is MetaEntry {
+  return Boolean(
+    entry &&
+      typeof entry === 'object' &&
+      'title' in entry &&
+      typeof (entry as { title: unknown }).title === 'string' &&
+      'value' in entry
+  );
+}
+
+/**
  * Safely parses and validates test context from JSON string
  * @param {string | undefined} metaJson - JSON string containing context metadata
  * @returns Valid context object or empty one when context is absent/invalid
@@ -13,10 +35,34 @@ function parseMeta(metaJson: string | undefined): Record<string, any> {
   }
 
   try {
-    const parsed = JSON.parse(metaJson);
-    // Ensure it's a valid object (Record<string, any>)
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return {meta: parsed};
+    let parsed = JSON.parse(metaJson);
+
+    // handle case when meta info can contain just one meta entry
+    // in such case it won't be an array but a single object, e.g.:
+    // "context": "{\n  \"title\": \"video\",\n  \"value\": \"videos/graphQL.mfa.errors.cy.ts.mp4\"\n}"
+    if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+      parsed = [parsed];
+    }
+
+    // Expected format to be processed:
+    // "context": "[\n  {\n    \"title\": \"video\",\n    \"value\": \"videos/graphQL.mfa.customFactor.cy.ts.mp4\"\n  },\n  {\n    \"title\": \"tags\",\n    \"value\": [\n      \"email\",\n      \"mfa\",\n      \"regression\",\n      \"smoke\",\n      \"P1\",\n      \"fallback-template\"\n    ]\n  }\n]",
+    // skip older entries, like:
+    // "context": "\"videos/api/firstCheck.spec.begin.ts.mp4\""
+    // Parse and validate context: ensure correct format and that context contains a Record<string: any>
+    // If valid JSON and proper format, use it; otherwise use an empty object and skip adding it going forward.
+    if (Array.isArray(parsed)) {
+      const mapped: Record<string, unknown> = {};
+
+      for (const item of parsed) {
+        if (!isMetaEntry(item) || item.title.trim() === '') {
+          continue;
+        }
+
+        // Reformat [{title:<title1>, value:<value1>}, ...] to {title1: value1, ...}
+        mapped[item.title] = item.value;
+      }
+
+      return Object.keys(mapped).length > 0 ? { meta: mapped } : {};
     }
 
     // Ignore unexpected non-object JSON payloads
@@ -71,13 +117,9 @@ export function parseTestsFromReports(
             title = 'Unable to detect test suite name';
           }
 
-          // Evaluate test.context
-          // In older versions it might have different format, thus such cases should be skipped
-          // e.g.: "context": "\"videos/api/firstCheck.spec.begin.ts.mp4\"",
-          // Expected format to be processed:
-          // "context": "{\n  \"video\": \"videos/graphQL.mfa.customFactor.cy.ts.mp4\",\n  \"tags\": [\n    \"email\",\n    \"mfa\",\n    \"regression\",\n    \"smoke\",\n    \"P1\",\n    \"fallback-template\"\n  ]\n}",
-          // Parse and validate context: ensure correct format and that context contains a Record<string: any>
-          // If valid JSON and proper format, use it; otherwise use an empty object and skip adding it going forward.
+          // Evaluate test.context,
+          // which was assigned to 'meta' attribute in src/utils/ingest/parseJsonReport.ts
+          // to avoid confusion with TestRail's 'context' attribute
           const metaInfo = parseMeta(testcase.meta);
 
           if (testcase.failures.length > 0) {

--- a/src/utils/testrail/parser.ts
+++ b/src/utils/testrail/parser.ts
@@ -1,6 +1,33 @@
 import type { JRRun, TestWithStatus } from '../../types/index.js';
 
 /**
+ * Safely parses and validates test context from JSON string
+ * @param {string | undefined} metaJson - JSON string containing context metadata
+ * @returns Valid context object or empty object if parsing fails
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseMeta(metaJson: string | undefined): Record<string, any> {
+  // Undefined, empty string, or whitespace-only JSON - return empty object
+  if (!metaJson || metaJson.trim() === '') {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(metaJson);
+    // Ensure it's a valid object (Record<string, any>)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed;
+    }
+
+    // Return empty object if "context" has unexpected format
+    return {};
+  } catch {
+    // Invalid JSON or improper format - return empty object
+    return {};
+  }
+}
+
+/**
  * Parses test reports from a JRRun and converts them into TestRail-compatible format
  * @param jrRun - The ingested test run data
  * @param logger - Optional logging function
@@ -44,6 +71,15 @@ export function parseTestsFromReports(
             title = 'Unable to detect test suite name';
           }
 
+          // Evaluate test.context
+          // In older versions it might have different format, thus such cases should be skipped
+          // e.g.: "context": "\"videos/api/firstCheck.spec.begin.ts.mp4\"",
+          // Expected format to be processed:
+          // "context": "{\n  \"video\": \"videos/graphQL.mfa.customFactor.cy.ts.mp4\",\n  \"tags\": [\n    \"email\",\n    \"mfa\",\n    \"regression\",\n    \"smoke\",\n    \"P1\",\n    \"fallback-template\"\n  ]\n}",
+          // Parse and validate context: ensure correct format and that context contains a Record<string: any>
+          // If valid JSON and proper format, use it; otherwise assign an empty object
+          const metaInfo = parseMeta(testcase.meta);
+
           if (testcase.failures.length > 0) {
             const comment = testcase.failures
               .filter((failure) => failure && failure.text) // Filter out undefined failures
@@ -63,6 +99,7 @@ export function parseTestsFromReports(
 
             return {
               comment,
+              meta: metaInfo,
               section,
               status,
               steps: testcase.steps,
@@ -82,6 +119,7 @@ export function parseTestsFromReports(
             }
 
             return {
+              meta: metaInfo,
               section,
               status: 'SKIP' as const,
               steps: testcase.steps,
@@ -95,6 +133,7 @@ export function parseTestsFromReports(
           }
 
           return {
+            meta: metaInfo,
             section,
             status: 'PASS' as const,
             steps: testcase.steps,

--- a/src/utils/testrail/parser.ts
+++ b/src/utils/testrail/parser.ts
@@ -3,11 +3,11 @@ import type { JRRun, TestWithStatus } from '../../types/index.js';
 /**
  * Safely parses and validates test context from JSON string
  * @param {string | undefined} metaJson - JSON string containing context metadata
- * @returns Valid context object or empty object if parsing fails
+ * @returns Valid context object or empty one when context is absent/invalid
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseMeta(metaJson: string | undefined): Record<string, any> {
-  // Undefined, empty string, or whitespace-only JSON - return empty object
+  // Undefined, empty string, or whitespace-only JSON
   if (!metaJson || metaJson.trim() === '') {
     return {};
   }
@@ -16,13 +16,13 @@ function parseMeta(metaJson: string | undefined): Record<string, any> {
     const parsed = JSON.parse(metaJson);
     // Ensure it's a valid object (Record<string, any>)
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed;
+      return {meta: parsed};
     }
 
-    // Return empty object if "context" has unexpected format
+    // Ignore unexpected non-object JSON payloads
     return {};
   } catch {
-    // Invalid JSON or improper format - return empty object
+    // Invalid JSON or improper format
     return {};
   }
 }
@@ -77,7 +77,7 @@ export function parseTestsFromReports(
           // Expected format to be processed:
           // "context": "{\n  \"video\": \"videos/graphQL.mfa.customFactor.cy.ts.mp4\",\n  \"tags\": [\n    \"email\",\n    \"mfa\",\n    \"regression\",\n    \"smoke\",\n    \"P1\",\n    \"fallback-template\"\n  ]\n}",
           // Parse and validate context: ensure correct format and that context contains a Record<string: any>
-          // If valid JSON and proper format, use it; otherwise assign an empty object
+          // If valid JSON and proper format, use it; otherwise use an empty object and skip adding it going forward.
           const metaInfo = parseMeta(testcase.meta);
 
           if (testcase.failures.length > 0) {
@@ -99,7 +99,7 @@ export function parseTestsFromReports(
 
             return {
               comment,
-              meta: metaInfo,
+              ...metaInfo,
               section,
               status,
               steps: testcase.steps,
@@ -119,7 +119,7 @@ export function parseTestsFromReports(
             }
 
             return {
-              meta: metaInfo,
+              ...metaInfo,
               section,
               status: 'SKIP' as const,
               steps: testcase.steps,
@@ -133,7 +133,7 @@ export function parseTestsFromReports(
           }
 
           return {
-            meta: metaInfo,
+            ...metaInfo,
             section,
             status: 'PASS' as const,
             steps: testcase.steps,

--- a/src/utils/testrail/results.ts
+++ b/src/utils/testrail/results.ts
@@ -1,4 +1,4 @@
-import { TestRailConfig, TestRailResult } from '../../types/index.js';
+import { TestRailConfig, TestRailResult, UpdateCase } from '../../types/index.js';
 import { sendRequest } from './client.js';
 
 export const addTestrailResults = async (
@@ -9,8 +9,24 @@ export const addTestrailResults = async (
   (await sendRequest(
     config,
     'POST',
-    'add_results_for_cases/' + runId.toString(),
-    {
-      results,
-    },
+    `add_results_for_cases/${runId}`,
+    {results}
+  )) as TestRailResult[];
+
+/**
+ * Updates TestRail test-case
+ * @param {TestRailConfig} config TestRail config
+ * @param {number} caseId test-case ID
+ * @param {UpdateCase} body object with new test-case's attributes to be updated
+ */
+export const updateTestCase = async (
+  config: TestRailConfig,
+  caseId: number,
+  body: UpdateCase,
+): Promise<TestRailResult[]> =>
+  (await sendRequest(
+    config,
+    'POST',
+    `update_case/${caseId}`,
+    body
   )) as TestRailResult[];

--- a/test/parseJsonReport.test.ts
+++ b/test/parseJsonReport.test.ts
@@ -654,6 +654,51 @@ describe('parseJsonReport', () => {
       });
     });
 
+    it('should preserve testcase context in meta when it contains mixed entities', () => {
+      const rawReports = [
+        {
+          filepath: '/path/to/report.json',
+          content: {
+            stats: {
+              failures: 0,
+              pending: 0,
+              skipped: 0,
+              tests: 1,
+              duration: 200,
+              start: '2024-01-01T10:00:00.000Z',
+            },
+            results: [
+              {
+                uuid: 'suite-1',
+                title: 'Suite',
+                tests: [
+                  {
+                    title: 'test with context',
+                    duration: 100,
+                    fail: false,
+                    pending: false,
+                    code: '',
+                    context: ['raw-string', { tags: ['regression'], video: 'run.mp4' }],
+                    err: { estack: '' },
+                  },
+                ],
+                suites: [],
+                failures: [],
+                pending: [],
+                skipped: [],
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = parseJson(rawReports);
+
+      expect(result.reports[0].testsuites[0].tests[0]).toMatchObject({
+        meta: ['raw-string', { tags: ['regression'], video: 'run.mp4' }],
+      });
+    });
+
     it('should not include meta when testcase context is absent or null', () => {
       const rawReports = [
         {

--- a/test/parseJsonReport.test.ts
+++ b/test/parseJsonReport.test.ts
@@ -755,8 +755,8 @@ describe('parseJsonReport', () => {
 
       const result = parseJson(rawReports);
 
-      expect(result.reports[0].testsuites[0].tests[0]).not.toHaveProperty('meta');
-      expect(result.reports[0].testsuites[0].tests[1]).not.toHaveProperty('meta');
+      expect(result.reports[0].testsuites[0].tests[0]).toMatchObject({meta: 'raw-context-string'});
+      expect(result.reports[0].testsuites[0].tests[1]).toMatchObject({meta: ['tagA', 'tagB']});
     });
 
     it('should handle mixed report validity (some valid, some invalid)', () => {

--- a/test/parseJsonReport.test.ts
+++ b/test/parseJsonReport.test.ts
@@ -609,6 +609,156 @@ describe('parseJsonReport', () => {
       expect(result.reports[0].testsuites[0].tests[0].steps).toBe(testCode);
     });
 
+    it('should preserve testcase context in meta when provided', () => {
+      const rawReports = [
+        {
+          filepath: '/path/to/report.json',
+          content: {
+            stats: {
+              failures: 0,
+              pending: 0,
+              skipped: 0,
+              tests: 1,
+              duration: 200,
+              start: '2024-01-01T10:00:00.000Z',
+            },
+            results: [
+              {
+                uuid: 'suite-1',
+                title: 'Suite',
+                tests: [
+                  {
+                    title: 'test with context',
+                    duration: 100,
+                    fail: false,
+                    pending: false,
+                    code: '',
+                    context: { tags: ['regression'], video: 'run.mp4' },
+                    err: { estack: '' },
+                  },
+                ],
+                suites: [],
+                failures: [],
+                pending: [],
+                skipped: [],
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = parseJson(rawReports);
+
+      expect(result.reports[0].testsuites[0].tests[0]).toMatchObject({
+        meta: { tags: ['regression'], video: 'run.mp4' },
+      });
+    });
+
+    it('should not include meta when testcase context is absent or null', () => {
+      const rawReports = [
+        {
+          filepath: '/path/to/report.json',
+          content: {
+            stats: {
+              failures: 0,
+              pending: 0,
+              skipped: 0,
+              tests: 2,
+              duration: 250,
+              start: '2024-01-01T10:00:00.000Z',
+            },
+            results: [
+              {
+                uuid: 'suite-1',
+                title: 'Suite',
+                tests: [
+                  {
+                    title: 'test without context',
+                    duration: 100,
+                    fail: false,
+                    pending: false,
+                    code: '',
+                    err: { estack: '' },
+                  },
+                  {
+                    title: 'test with null context',
+                    duration: 100,
+                    fail: false,
+                    pending: false,
+                    code: '',
+                    context: null,
+                    err: { estack: '' },
+                  },
+                ],
+                suites: [],
+                failures: [],
+                pending: [],
+                skipped: [],
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = parseJson(rawReports);
+
+      expect(result.reports[0].testsuites[0].tests[0]).not.toHaveProperty('meta');
+      expect(result.reports[0].testsuites[0].tests[1]).not.toHaveProperty('meta');
+    });
+
+    it('should ignore meta when testcase context has an improper format', () => {
+      const rawReports = [
+        {
+          filepath: '/path/to/report.json',
+          content: {
+            stats: {
+              failures: 0,
+              pending: 0,
+              skipped: 0,
+              tests: 2,
+              duration: 250,
+              start: '2024-01-01T10:00:00.000Z',
+            },
+            results: [
+              {
+                uuid: 'suite-1',
+                title: 'Suite',
+                tests: [
+                  {
+                    title: 'test with string context',
+                    duration: 100,
+                    fail: false,
+                    pending: false,
+                    code: '',
+                    context: 'raw-context-string',
+                    err: { estack: '' },
+                  },
+                  {
+                    title: 'test with array context',
+                    duration: 100,
+                    fail: false,
+                    pending: false,
+                    code: '',
+                    context: ['tagA', 'tagB'],
+                    err: { estack: '' },
+                  },
+                ],
+                suites: [],
+                failures: [],
+                pending: [],
+                skipped: [],
+              },
+            ],
+          },
+        },
+      ];
+
+      const result = parseJson(rawReports);
+
+      expect(result.reports[0].testsuites[0].tests[0]).not.toHaveProperty('meta');
+      expect(result.reports[0].testsuites[0].tests[1]).not.toHaveProperty('meta');
+    });
+
     it('should handle mixed report validity (some valid, some invalid)', () => {
       const rawReports = [
         {

--- a/test/testrailParser.test.ts
+++ b/test/testrailParser.test.ts
@@ -656,6 +656,192 @@ describe('parseTestsFromReports', () => {
     });
   });
 
+  describe('meta parsing', () => {
+    it('should include meta when testcase meta is valid JSON object', () => {
+      const jrRun = createJRRun([
+        {
+          failures: 0,
+          name: 'Report',
+          pending: 0,
+          skipped: 0,
+          tests: 1,
+          testsuites: [
+            {
+              failures: 0,
+              name: 'Suite',
+              pending: 0,
+              skipped: 0,
+              tests: [
+                {
+                  failures: [],
+                  meta: '{"tags":["smoke"],"video":"run.mp4"}',
+                  name: 'test with meta',
+                  status: 'PASS',
+                  time: 10,
+                },
+              ],
+              time: 10,
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+          time: 10,
+        },
+      ]);
+
+      const result = parseTestsFromReports(jrRun);
+
+      expect(result[0]).toMatchObject({
+        meta: { tags: ['smoke'], video: 'run.mp4' },
+      });
+    });
+
+    it('should ignore testcase meta when JSON is invalid', () => {
+      const jrRun = createJRRun([
+        {
+          failures: 0,
+          name: 'Report',
+          pending: 0,
+          skipped: 0,
+          tests: 1,
+          testsuites: [
+            {
+              failures: 0,
+              name: 'Suite',
+              pending: 0,
+              skipped: 0,
+              tests: [
+                {
+                  failures: [],
+                  meta: '{invalid-json',
+                  name: 'test with invalid meta',
+                  status: 'PASS',
+                  time: 10,
+                },
+              ],
+              time: 10,
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+          time: 10,
+        },
+      ]);
+
+      const result = parseTestsFromReports(jrRun);
+
+      expect(result[0]).not.toHaveProperty('meta');
+    });
+
+    it('should ignore testcase meta when JSON is not an object', () => {
+      const jrRun = createJRRun([
+        {
+          failures: 0,
+          name: 'Report',
+          pending: 0,
+          skipped: 0,
+          tests: 1,
+          testsuites: [
+            {
+              failures: 0,
+              name: 'Suite',
+              pending: 0,
+              skipped: 0,
+              tests: [
+                {
+                  failures: [],
+                  meta: '["tag1","tag2"]',
+                  name: 'test with array meta',
+                  status: 'PASS',
+                  time: 10,
+                },
+              ],
+              time: 10,
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+          time: 10,
+        },
+      ]);
+
+      const result = parseTestsFromReports(jrRun);
+
+      expect(result[0]).not.toHaveProperty('meta');
+    });
+  });
+
+  describe('title edge cases', () => {
+    it('should trim test title to the last 240 characters when too long', () => {
+      const longTitle = `prefix-${'x'.repeat(300)}`;
+      const jrRun = createJRRun([
+        {
+          failures: 0,
+          name: 'Report',
+          pending: 0,
+          skipped: 0,
+          tests: 1,
+          testsuites: [
+            {
+              failures: 0,
+              name: 'Suite',
+              pending: 0,
+              skipped: 0,
+              tests: [
+                {
+                  failures: [],
+                  name: longTitle,
+                  status: 'PASS',
+                  time: 10,
+                },
+              ],
+              time: 10,
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+          time: 10,
+        },
+      ]);
+
+      const result = parseTestsFromReports(jrRun);
+
+      expect(result[0].title).toHaveLength(240);
+      expect(result[0].title).toBe(longTitle.slice(-240));
+    });
+
+    it('should use fallback title when title is empty after section removal', () => {
+      const jrRun = createJRRun([
+        {
+          failures: 0,
+          name: 'Report',
+          pending: 0,
+          skipped: 0,
+          tests: 1,
+          testsuites: [
+            {
+              failures: 0,
+              name: 'Login',
+              pending: 0,
+              skipped: 0,
+              tests: [
+                {
+                  failures: [],
+                  name: 'Login',
+                  status: 'PASS',
+                  time: 10,
+                },
+              ],
+              time: 10,
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+          time: 10,
+        },
+      ]);
+
+      const result = parseTestsFromReports(jrRun);
+
+      expect(result[0].title).toBe('Unable to detect test suite name');
+    });
+  });
+
   describe('status variations', () => {
     it('should handle skipped status in failures array', () => {
       const jrRun = createJRRun([

--- a/test/testrailParser.test.ts
+++ b/test/testrailParser.test.ts
@@ -657,7 +657,7 @@ describe('parseTestsFromReports', () => {
   });
 
   describe('meta parsing', () => {
-    it('should include meta when testcase meta is valid JSON object', () => {
+    it('should ignore testcase meta when JSON is a plain object', () => {
       const jrRun = createJRRun([
         {
           failures: 0,
@@ -690,9 +690,7 @@ describe('parseTestsFromReports', () => {
 
       const result = parseTestsFromReports(jrRun);
 
-      expect(result[0]).toMatchObject({
-        meta: { tags: ['smoke'], video: 'run.mp4' },
-      });
+      expect(result[0]).not.toHaveProperty('meta');
     });
 
     it('should ignore testcase meta when JSON is invalid', () => {
@@ -731,7 +729,7 @@ describe('parseTestsFromReports', () => {
       expect(result[0]).not.toHaveProperty('meta');
     });
 
-    it('should ignore testcase meta when JSON is not an object', () => {
+    it('should reformat testcase meta when JSON is an array of title/value pairs', () => {
       const jrRun = createJRRun([
         {
           failures: 0,
@@ -748,8 +746,82 @@ describe('parseTestsFromReports', () => {
               tests: [
                 {
                   failures: [],
-                  meta: '["tag1","tag2"]',
+                  meta: '[{"title":"video","value":"run.mp4"},{"title":"tags","value":["smoke","p1"]}]',
                   name: 'test with array meta',
+                  status: 'PASS',
+                  time: 10,
+                },
+              ],
+              time: 10,
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+          time: 10,
+        },
+      ]);
+
+      const result = parseTestsFromReports(jrRun);
+
+      expect(result[0]).toMatchObject({
+        meta: { tags: ['smoke', 'p1'], video: 'run.mp4' },
+      });
+    });
+
+    it('should ignore testcase meta when JSON array does not contain valid title/value pairs', () => {
+      const jrRun = createJRRun([
+        {
+          failures: 0,
+          name: 'Report',
+          pending: 0,
+          skipped: 0,
+          tests: 1,
+          testsuites: [
+            {
+              failures: 0,
+              name: 'Suite',
+              pending: 0,
+              skipped: 0,
+              tests: [
+                {
+                  failures: [],
+                  meta: '[{"title":"","value":"ignored"},{"value":"missing-title"},42]',
+                  name: 'test with invalid array meta',
+                  status: 'PASS',
+                  time: 10,
+                },
+              ],
+              time: 10,
+              timestamp: '2024-01-01T00:00:00Z',
+            },
+          ],
+          time: 10,
+        },
+      ]);
+
+      const result = parseTestsFromReports(jrRun);
+
+      expect(result[0]).not.toHaveProperty('meta');
+    });
+
+    it('should ignore testcase meta when JSON is a primitive value', () => {
+      const jrRun = createJRRun([
+        {
+          failures: 0,
+          name: 'Report',
+          pending: 0,
+          skipped: 0,
+          tests: 1,
+          testsuites: [
+            {
+              failures: 0,
+              name: 'Suite',
+              pending: 0,
+              skipped: 0,
+              tests: [
+                {
+                  failures: [],
+                  meta: '"legacy-string-context"',
+                  name: 'test with primitive meta',
                   status: 'PASS',
                   time: 10,
                 },

--- a/test/testrailResults.test.ts
+++ b/test/testrailResults.test.ts
@@ -1,6 +1,6 @@
-import type { TestRailConfig, TestRailResult } from '../src/types/index.js';
+import type { TestRailConfig, TestRailResult, UpdateCase } from '../src/types/index.js';
 
-import { addTestrailResults } from '../src/utils/testrail/results.js';
+import { addTestrailResults, updateTestCase } from '../src/utils/testrail/results.js';
 import { sendRequest } from '../src/utils/testrail/client.js';
 
 // Mock the client module
@@ -93,6 +93,38 @@ describe('TestRail Results', () => {
         'POST',
         'add_results_for_cases/12345',
         expect.any(Object),
+      );
+    });
+  });
+
+  describe('updateTestCase', () => {
+    it('should call sendRequest with correct endpoint and body', async () => {
+      const body: UpdateCase = { title: 'Updated title', steps: 'Step 1' };
+      const mockResponse = [{ case_id: 42, status_id: 1 }];
+      mockSendRequest.mockReturnValue(mockResponse);
+
+      const result = await updateTestCase(mockConfig, 42, body);
+
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        mockConfig,
+        'POST',
+        'update_case/42',
+        body,
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should pass partial update body', async () => {
+      const body: UpdateCase = { comment: 'needs review' };
+      mockSendRequest.mockReturnValue([]);
+
+      await updateTestCase(mockConfig, 7, body);
+
+      expect(mockSendRequest).toHaveBeenCalledWith(
+        mockConfig,
+        'POST',
+        'update_case/7',
+        body,
       );
     });
   });


### PR DESCRIPTION
- If Cypress test results contain `context` attribute in the format of object, this meta information will be parsed and `labels` field in corresponding `TestRail` test-case will be updated with `tags` fetched from that object.
- If fetched `tags` and existing `TestRail` `labels` are equal - _no update_ will be made
- If there is a difference - `TestRail` `labels` will be _overwritten_ with new `tags`
- If `context` is absent in results or doesn't contain data in expected format - it will be _ignored_.
```
          "tests": [
            {
              "title": "Should throw an error when an invalid username is provided",
              "fullTitle": "Error scenarios common to all factors Should throw an error when an invalid username is provided",
              "timedOut": null,
              "duration": 320,
              "state": "passed",
              "speed": "fast",
              "pass": true,
              "fail": false,
              "pending": false,
              "context": "{\n  \"video\": \"videos/graphQL.mfa.errors.cy.ts.mp4\",\n  \"tags\": [\n    \"email\",\n    \"mfa\",\n    \"regression\"]\n}",
              "code": "(0, utils_1.initiateAndExpectGlobalError)('unknownUser', pwd, 'authentication_failed');",
              "err": {},
              "uuid": "a85c5199-79fe-442d-a3b2-dfd101a24422",
              "parentUUID": "91449ff2-08c1-4cb2-ace3-1e09144900eb",
              "isHook": false,
              "skipped": false
            },
            {
              "title": "Should throw an error when an invalid password is provided",
              "fullTitle": "Error scenarios common to all factors Should throw an error when an invalid password is provided",
              "timedOut": null,
              "duration": 236,
              "state": "passed",
              "speed": "fast",
              "pass": true,
              "fail": false,
              "pending": false,
              "context": "{\n  \"video\": \"videos/graphQL.mfa.errors.cy.ts.mp4\"\n}",
              "code": "(0, utils_1.initiateAndExpectGlobalError)(usr, 'myPassword', 'authentication_failed');",
              "err": {},
              "uuid": "896cf1b2-bda0-4d71-b954-66b256655273",
              "parentUUID": "91449ff2-08c1-4cb2-ace3-1e09144900eb",
              "isHook": false,
              "skipped": false
            },
```
<kbd>
<img width="720" height="282" alt="image" src="https://github.com/user-attachments/assets/c5ad8db9-e80d-42e6-a0a2-10a4caa574cf" />
</kbd>